### PR TITLE
feat: Add support for reporting on Kubernetes workload resource findings for min replicas and `minReadySeconds`

### DIFF
--- a/docs/process/checks.md
+++ b/docs/process/checks.md
@@ -29,7 +29,7 @@ There is a sufficient quantity of IPs available for the **pods** to support the 
 
 This check is used when custom networking is enabled since the IPs used by pods are coming from subnets different from those used by the EC2 instances themselves.
 
-<!-- #### AWS003
+#### AWS003
 !!! info "🚧 _Not yet implemented_"
 
 EC2 instance service limits
@@ -42,7 +42,7 @@ EBS GP2 volume service limits
 #### AWS005
 !!! info "🚧 _Not yet implemented_"
 
-EBS GP3 volume service limits -->
+EBS GP3 volume service limits
 
 ---
 

--- a/docs/process/checks.md
+++ b/docs/process/checks.md
@@ -138,8 +138,6 @@ Table below shows the checks that are applicable, or not, to the respective Kube
 
 #### K8S001
 
-!!! info "🚧 _Not yet implemented_"
-
 **❌ Remediation required**
 
 The version skew between the control plane (API Server) and the data plane (kubelet) violates the Kubernetes version skew policy, or will violate the version skew policy after the control plane has been upgraded.
@@ -155,8 +153,6 @@ While Kubernetes does support a version skew of n-2 between the API Server and k
 [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/#supported-version-skew)
 
 #### K8S002
-
-!!! info "🚧 _Not yet implemented_"
 
 **❌ Remediation required**
 
@@ -174,8 +170,6 @@ Multiple replicas, along with the use of `PodDisruptionBudget`, are required to 
 [EKS Best Practices - Reliability](https://aws.github.io/aws-eks-best-practices/reliability/docs/application/#run-multiple-replicas)
 
 #### K8S003
-
-!!! info "🚧 _Not yet implemented_"
 
 **❌ Remediation required**
 

--- a/docs/scratch.md
+++ b/docs/scratch.md
@@ -46,8 +46,8 @@ A check must be able to answer `yes` to one of the following questions, dependin
 | [`K8S009`] |     -      |     -      |           -           |      -      |  -  |    -    |     -     |
 | [`K8S010`] |     -      |     -      |           -           |      -      |  -  |    -    |     -     |
 
-- [ ] [`K8S002`] `.spec.replicas` set >= 3
-- [ ] [`K8S003`] `.spec.minReadySeconds` set > 0 - https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+- [x] [`K8S002`] `.spec.replicas` set >= 3
+- [x] [`K8S003`] `.spec.minReadySeconds` set > 0 - https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 - [ ] [`K8S004`] `podDisruptionBudgets` set & at least one of `minAvailable` or `maxUnavailable` is set
 - [ ] [`K8S005`] Either `.spec.affinity.podAntiAffinity` or `.spec.topologySpreadConstraints` set to avoid multiple pods from being scheduled on the same node. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   - [ ] Prefer topology hints over affinity `Note: Inter-pod affinity and anti-affinity require substantial amount of processing which can slow down scheduling in large clusters significantly. We do not recommend using them in clusters larger than several hundred nodes.` https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
@@ -56,10 +56,6 @@ A check must be able to answer `yes` to one of the following questions, dependin
   - [ ] `.spec.containers[*].startupProbe` is set if `.spec.containers[*].livenessProbe` is set
 - [ ] [`K8S007`] `pod.Spec.TerminationGracePeriodSeconds` > 0 - The StatefulSet should not specify a pod.Spec.TerminationGracePeriodSeconds of 0 https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#deployment-and-scaling-guarantees
   - (StatefulSet)
-
-#### Job/CronJob
-
-- [ ] [`K8S---`] `.spec.suspend` set to `true` before upgrading, removed after upgrade (see questions - what is the best guidance for batch workloads?)
 
 ### Kubernetes Deprecations
 

--- a/eksup/README.md
+++ b/eksup/README.md
@@ -1,0 +1,85 @@
+# eksup
+
+See the docs at [clowdhaus.github.io/eksup](https://clowdhaus.github.io/eksup/)
+
+## Installation
+
+[Archives of pre-compiled binaries for `eksup` are available for Windows, macOS and Linux.](https://github.com/clowdhaus/eksup/releases)
+
+### Homebrew (macOS and Linux)
+
+```sh
+brew install clowdhaus/taps/eksup
+```
+
+### Cargo (rust)
+
+```sh
+cargo install eksup
+```
+
+### Source
+
+`eksup` is written in Rust, so you'll need to grab a [Rust installation](https://www.rust-lang.org/) in order to compile it.
+`eksup` compiles with Rust 1.65.0 (stable) or newer. In general, `eksup` tracks the latest stable release of the Rust compiler.
+
+To build `eksup`:
+
+```sh
+git clone https://github.com/clowdhaus/eksup
+cd eksup
+cargo build --release
+./target/release/eksup --version
+0.1.1-alpha
+```
+
+## Local Development
+
+`eksup` uses Rust stable for production builds, but nightly for local development for formatting and linting. It is not a requirement to use nightly, but if running `fmt` you may see a few warnings on certain features only being available on nightly.
+
+Build the project to pull down dependencies and ensure everything is setup properly:
+
+```sh
+cargo build
+```
+
+To format the codebase:
+
+If using nightly to use features defined in [rustfmt.toml](rustfmt.toml), run the following:
+
+```sh
+cargo +nightly fmt --all
+```
+
+If using stable, run the following:
+
+```sh
+cargo fmt --all
+```
+
+To execute lint checks:
+
+```sh
+cargo clippy --all-targets --all-features
+```
+
+To run `eksup` locally for development, simply pass `eksup` commands and arguments after `cargo run --` as follows:
+
+```sh
+cargo run -- analyze --cluster <cluster> --region <region>
+```
+
+You can think of `cargo run --` as an alias for `eksup` when running locally.
+Note: you will need to have access to the cluster you are analyzing. This is generally done by ensuring you have a valid `~/.kube/config` file; one can be created/updated by running:
+
+```sh
+aws eks update-kubeconfig --name <cluster> --region <region>
+```
+
+### Running Tests
+
+To execute the tests provided, run the following from the project root directory:
+
+```sh
+cargo test --all
+```

--- a/eksup/src/analysis.rs
+++ b/eksup/src/analysis.rs
@@ -87,6 +87,25 @@ async fn get_addon_findings(
   })
 }
 
+/// Findings collected from the Kubernetes workload resources running on the cluster
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct K8sWorkloadResourceFindings {
+  /// Reports any health issues as reported by the Amazon EKS addon API
+  pub(crate) min_replicas: Vec<k8s::MinReplicas>,
+}
+
+// /// Collects the findings from the Kubernetes workload resources running on the cluster
+// async fn get_k8s_workload_findings(
+//   k8s_client: &K8sClient,
+//   cluster: &Cluster,
+// ) -> Result<K8sWorkloadResourceFindings> {
+//   let min_replicas = k8s::min_replicas(k8s_client, cluster).await?;
+//   Ok(SubnetFindings {
+//     control_plane_ips,
+//     pod_ips,
+//   })
+// }
+
 /// Findings related to the data plane infrastructure components
 ///
 /// This does not include findings for resources that are running on the cluster, within the data plane

--- a/eksup/src/k8s.rs
+++ b/eksup/src/k8s.rs
@@ -209,15 +209,6 @@ pub(crate) struct MinReadySecondsFinding {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct UpdateStrategyFinding {
-  pub(crate) resource: Resource,
-  /// Update strategy
-  pub(crate) strategy: String,
-  pub(crate) remediation: finding::Remediation,
-  pub(crate) fcode: finding::Code,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PodDisruptionBudgetFinding {
   pub(crate) resource: Resource,
   /// Has pod associated pod disruption budget
@@ -270,9 +261,9 @@ pub(crate) struct DockerSocketFinding {
 pub(crate) trait K8sFindings {
   fn get_resource(&self) -> Resource;
   /// K8S002 - check if resources contain a minimum of 3 replicas
-  fn min_replicas(&self) -> Result<Option<MinReplicas>>;
+  fn min_replicas(&self) -> Option<MinReplicas>;
   /// K8S003 - check if resources contain minReadySeconds > 0
-  fn min_ready_seconds(&self) -> Result<Option<MinReadySecondsFinding>>;
+  fn min_ready_seconds(&self) -> Option<MinReadySecondsFinding>;
   // /// K8S004 - check if resources have associated podDisruptionBudgets
   // fn pod_disruption_budget(&self) -> Result<Option<PodDisruptionBudgetFinding>>;
   // /// K8S005 - check if resources have podAntiAffinity or topologySpreadConstraints
@@ -300,28 +291,6 @@ pub(crate) struct StdMetadata {
   pub(crate) kind: String,
   pub(crate) labels: BTreeMap<String, String>,
   pub(crate) annotations: BTreeMap<String, String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum UpdateStrategy {
-  RollingUpdate,
-  ReCreate,
-  OnDelete,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct StdUpdateStrategy {
-  /// RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
-  pub rolling_update: Option<UpdateStrategy>,
-
-  /// Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
-  pub type_: Option<String>,
-
-  /// The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
-  pub max_surge: Option<k8s_openapi::apimachinery::pkg::util::intstr::IntOrString>,
-
-  /// The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
-  pub max_unavailable: Option<k8s_openapi::apimachinery::pkg::util::intstr::IntOrString>,
 }
 
 /// This is a generalized spec used across all resource types that
@@ -353,25 +322,30 @@ impl K8sFindings for StdResource {
     }
   }
 
-  fn min_replicas(&self) -> Result<Option<MinReplicas>> {
-    let replicas = self.spec.replicas.unwrap_or(1);
-    let finding = if replicas < 3 {
-      Some(MinReplicas {
-        resource: self.get_resource(),
-        replicas,
-        remediation: finding::Remediation::Required,
-        fcode: finding::Code::K8S002,
-      })
-    } else {
-      None
-    };
+  fn min_replicas(&self) -> Option<MinReplicas> {
+    let replicas = self.spec.replicas;
 
-    Ok(finding)
+    match replicas {
+      Some(replicas) => {
+        if replicas < 3 {
+          Some(MinReplicas {
+            resource: self.get_resource(),
+            replicas,
+            remediation: finding::Remediation::Required,
+            fcode: finding::Code::K8S002,
+          })
+        } else {
+          None
+        }
+      }
+      None => None,
+    }
   }
 
-  fn min_ready_seconds(&self) -> Result<Option<MinReadySecondsFinding>> {
+  fn min_ready_seconds(&self) -> Option<MinReadySecondsFinding> {
     let seconds = self.spec.min_ready_seconds.unwrap_or(0);
-    let finding = if seconds < 1 {
+
+    if seconds < 1 {
       Some(MinReadySecondsFinding {
         resource: self.get_resource(),
         seconds,
@@ -380,9 +354,7 @@ impl K8sFindings for StdResource {
       })
     } else {
       None
-    };
-
-    Ok(finding)
+    }
   }
 }
 
@@ -408,7 +380,6 @@ async fn get_deployments(client: &Client) -> Result<Vec<StdResource>> {
       let spec = StdSpec {
         min_ready_seconds: spec.min_ready_seconds,
         replicas: spec.replicas,
-        // strategy: spec.strategy,
         template: Some(spec.template),
       };
 
@@ -419,7 +390,7 @@ async fn get_deployments(client: &Client) -> Result<Vec<StdResource>> {
   Ok(deployments)
 }
 
-async fn get_replicasets(client: &Client) -> Result<Vec<StdResource>> {
+async fn _get_replicasets(client: &Client) -> Result<Vec<StdResource>> {
   let api: Api<apps::v1::ReplicaSet> = Api::all(client.clone());
   let replicaset_list = api.list(&Default::default()).await?;
 
@@ -441,7 +412,6 @@ async fn get_replicasets(client: &Client) -> Result<Vec<StdResource>> {
       let spec = StdSpec {
         min_ready_seconds: spec.min_ready_seconds,
         replicas: spec.replicas,
-        // strategy: None,
         template: spec.template,
       };
 
@@ -474,7 +444,6 @@ async fn get_statefulsets(client: &Client) -> Result<Vec<StdResource>> {
       let spec = StdSpec {
         min_ready_seconds: spec.min_ready_seconds,
         replicas: spec.replicas,
-        // strategy: spec.update_strategy,
         template: Some(spec.template),
       };
 
@@ -507,7 +476,6 @@ async fn get_daemonsets(client: &Client) -> Result<Vec<StdResource>> {
       let spec = StdSpec {
         min_ready_seconds: spec.min_ready_seconds,
         replicas: None,
-        // strategy: spec.update_strategy,
         template: Some(spec.template),
       };
 
@@ -540,7 +508,6 @@ async fn get_jobs(client: &Client) -> Result<Vec<StdResource>> {
       let spec = StdSpec {
         min_ready_seconds: None,
         replicas: None,
-        // strategy: None,
         template: Some(spec.template),
       };
 
@@ -573,7 +540,6 @@ async fn get_cronjobs(client: &Client) -> Result<Vec<StdResource>> {
       let spec = StdSpec {
         min_ready_seconds: None,
         replicas: None,
-        // strategy: None,
         template: match spec.job_template.spec {
           Some(spec) => Some(spec.template),
           None => None,
@@ -610,40 +576,15 @@ pub(crate) async fn get_resources(client: &Client) -> Result<Vec<StdResource>> {
   let daemonsets = get_daemonsets(client).await?;
   let deployments = get_deployments(client).await?;
   let jobs = get_jobs(client).await?;
-  let replicasets = get_replicasets(client).await?;
+  // let replicasets = get_replicasets(client).await?;
   let statefulsets = get_statefulsets(client).await?;
-
-  // for cron in &cronjobs {
-  //   println!("{:#?}", cron.min_replicas()?);
-  //   println!("{:#?}", cron.min_ready_seconds()?);
-  // }
-  // for daemon in &daemonsets {
-  //   println!("{:#?}", daemon.min_replicas()?);
-  //   println!("{:#?}", daemon.min_ready_seconds()?);
-  // }
-  // for deploy in deployments {
-  //   println!("{:#?}", deploy.min_replicas()?);
-  //   println!("{:#?}", deploy.min_ready_seconds()?);
-  // }
-  // for job in jobs {
-  //   println!("{:#?}", job.min_replicas()?);
-  //   println!("{:#?}", job.min_ready_seconds()?);
-  // }
-  // for repl in replicasets {
-  //   println!("{:#?}", repl.min_replicas()?);
-  //   println!("{:#?}", repl.min_ready_seconds()?);
-  // }
-  // for set in statefulsets {
-  //   println!("{:#?}", set.min_replicas()?);
-  //   println!("{:#?}", set.min_ready_seconds()?);
-  // }
 
   let mut resources = Vec::new();
   resources.extend(cronjobs);
   resources.extend(daemonsets);
   resources.extend(deployments);
   resources.extend(jobs);
-  resources.extend(replicasets);
+  // resources.extend(replicasets);
   resources.extend(statefulsets);
 
   Ok(resources)

--- a/eksup/src/playbook.rs
+++ b/eksup/src/playbook.rs
@@ -57,7 +57,7 @@ pub struct TemplateData {
   self_managed_nodegroup_template: String,
   fargate_profiles: Vec<String>,
   fargate_profile_template: String,
-  min_replicas: Option<String>,
+  kubernetes_findings: analysis::KubernetesFindings,
 }
 
 fn get_release_data() -> Result<HashMap<Version, Release>> {
@@ -177,7 +177,9 @@ pub(crate) fn create(args: &Playbook, cluster: &Cluster, analysis: analysis::Res
     self_managed_nodegroup_template,
     fargate_profiles,
     fargate_profile_template,
-    min_replicas: kubernetes_findings.min_replicas.to_markdown_table("\t"),
+    kubernetes_findings,
+    // min_replicas: kubernetes_findings.min_replicas.to_markdown_table("\t"),
+    // min_ready_seconds: kubernetes_findings.min_ready_seconds.to_markdown_table("\t"),
   };
 
   let filename = match &args.filename {

--- a/eksup/src/playbook.rs
+++ b/eksup/src/playbook.rs
@@ -57,6 +57,7 @@ pub struct TemplateData {
   self_managed_nodegroup_template: String,
   fargate_profiles: Vec<String>,
   fargate_profile_template: String,
+  min_replicas: Option<String>,
 }
 
 fn get_release_data() -> Result<HashMap<Version, Release>> {
@@ -120,6 +121,7 @@ pub(crate) fn create(args: &Playbook, cluster: &Cluster, analysis: analysis::Res
   let data_plane_findings = analysis.data_plane;
   let subnet_findings = analysis.subnets;
   let addon_findings = analysis.addons;
+  let kubernetes_findings = analysis.kubernetes;
 
   // Render sub-templates for data plane components
   let eks_managed_nodegroup_health = data_plane_findings.eks_managed_nodegroup_health.to_markdown_table("\t");
@@ -175,6 +177,7 @@ pub(crate) fn create(args: &Playbook, cluster: &Cluster, analysis: analysis::Res
     self_managed_nodegroup_template,
     fargate_profiles,
     fargate_profile_template,
+    min_replicas: kubernetes_findings.min_replicas.to_markdown_table("\t"),
   };
 
   let filename = match &args.filename {

--- a/eksup/templates/playbook.md
+++ b/eksup/templates/playbook.md
@@ -5,9 +5,9 @@
 | Amazon EKS cluster         |                 `{{ cluster_name }}`                      |
 | Current version            |                 `v{{ current_version }}`                  |
 | Target version             |                  `v{{ target_version }}`                  |
-| EKS Managed nodegroup(s)  | {{#if eks_managed_nodegroups }} ✅ {{ else }} ➖ {{/if}}  |
-| Self-Managed nodegroup(s) | {{#if self_managed_nodegroups }} ✅ {{ else }} ➖ {{/if}} |
-| Fargate profile(s)         |     {{#if fargate_profiles }} ✅ {{ else }} ➖ {{/if}}     |
+| EKS Managed nodegroup(s)  | {{#if data_plane_findings.eks_managed_nodegroups }} ✅ {{ else }} ➖ {{/if}}  |
+| Self-Managed nodegroup(s) | {{#if data_plane_findings.self_managed_nodegroups }} ✅ {{ else }} ➖ {{/if}} |
+| Fargate profile(s)         |     {{#if data_plane_findings.fargate_profiles }} ✅ {{ else }} ➖ {{/if}}     |
 
 ## Table of Contents
 
@@ -15,14 +15,14 @@
     - [Control Plane Pre-Upgrade](#control-plane-pre-upgrade)
     - [Control Plane Upgrade](#control-plane-upgrade)
 - [Upgrade the Data Plane](#upgrade-the-data-plane)
-{{#if eks_managed_nodegroups }}
+{{#if data_plane_findings.eks_managed_nodegroups }}
     - [Data Plane Pre-Upgrade](#data-plane-pre-upgrade)
         - [EKS Managed Nodegroup](#eks-managed-nodegroup)
 {{/if}}
-{{#if self_managed_nodegroups }}
+{{#if data_plane_findings.self_managed_nodegroups }}
         - [Self-Managed Nodegroup](#self-managed-nodegroup)
 {{/if}}
-{{#if fargate_profiles }}
+{{#if data_plane_findings.fargate_profiles }}
         - [Fargate Profile](#fargate-profile)
 {{/if}}
 - [Upgrade EKS Addons](#upgrade-eks-addons)
@@ -80,7 +80,7 @@
     </details>
 
     #### Check [[K8S001]](https://clowdhaus.github.io/eksup/process/checks/#k8s001)
-{{ version_skew }}
+{{ data_plane_findings.version_skew }}
 
 3. Verify that there are at least 5 free IPs in the VPC subnets used by the control plane. Amazon EKS creates new elastic network interfaces (ENIs) in any of the subnets specified for the control plane. If there are not enough available IPs, then the upgrade will fail (your control plane will stay on the prior version).
 
@@ -206,13 +206,13 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
 {{ pod_ips }}
 {{/if}}
 
-{{#if eks_managed_nodegroups }}
+{{#if data_plane_findings.eks_managed_nodegroups }}
 {{ eks_managed_nodegroup_template }}
 {{/if}}
-{{#if self_managed_nodegroups }}
+{{#if data_plane_findings.self_managed_nodegroups }}
 {{ self_managed_nodegroup_template }}
 {{/if}}
-{{#if fargate_profiles }}
+{{#if data_plane_findings.fargate_profiles }}
 {{ fargate_profile_template }}
 {{/if}}
 

--- a/eksup/templates/playbook.md
+++ b/eksup/templates/playbook.md
@@ -173,6 +173,9 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
 
     🚧 TODO - fill in analysis results
 
+    #### Check [[K8S002]](https://clowdhaus.github.io/eksup/process/checks/#k8s002)
+{{ min_replicas }}
+
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
 
 {{#if pod_ips}}

--- a/eksup/templates/playbook.md
+++ b/eksup/templates/playbook.md
@@ -174,7 +174,10 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
     🚧 TODO - fill in analysis results
 
     #### Check [[K8S002]](https://clowdhaus.github.io/eksup/process/checks/#k8s002)
-{{ min_replicas }}
+{{ kubernetes_findings.min_replicas }}
+
+    #### Check [[K8S003]](https://clowdhaus.github.io/eksup/process/checks/#k8s003)
+{{ kubernetes_findings.min_ready_seconds }}
 
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
 

--- a/examples/test-mixed_v1.24_upgrade.md
+++ b/examples/test-mixed_v1.24_upgrade.md
@@ -190,6 +190,9 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
 
 
 
+    #### Check [[K8S003]](https://clowdhaus.github.io/eksup/process/checks/#k8s003)
+	✅ - All relevant Kubernetes workloads minReadySeconds set to more than 0
+
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
 
 3. Verify that there is sufficient IP space available to the pods running in the cluster when using custom networking. With the in-place, surge upgrade process, there will be higher IP consumption during the upgrade.

--- a/examples/test-mixed_v1.24_upgrade.md
+++ b/examples/test-mixed_v1.24_upgrade.md
@@ -78,10 +78,10 @@
 
 	|   -   | Node Name | Kubelet Version | Control Plane Version |
 	| :---: | :-------- | :-------------- | :-------------------- |
-	| ⚠️ | `ip-10-0-13-231.ec2.internal` | `v1.22` | `v1.23` |
-	| ❌ | `ip-10-0-40-240.ec2.internal` | `v1.21` | `v1.23` |
-	| ❌ | `ip-10-0-41-155.ec2.internal` | `v1.21` | `v1.23` |
-	| ⚠️ | `ip-10-0-7-3.ec2.internal` | `v1.22` | `v1.23` |
+	| ❌ | `ip-10-0-21-97.ec2.internal` | `v1.21` | `v1.23` |
+	| ❌ | `ip-10-0-31-138.ec2.internal` | `v1.21` | `v1.23` |
+	| ⚠️ | `ip-10-0-46-208.ec2.internal` | `v1.22` | `v1.23` |
+	| ⚠️ | `ip-10-0-6-50.ec2.internal` | `v1.22` | `v1.23` |
 
 
 
@@ -181,6 +181,15 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
 
     🚧 TODO - fill in analysis results
 
+    #### Check [[K8S002]](https://clowdhaus.github.io/eksup/process/checks/#k8s002)
+	|  -  | Name | Namespace | Kind | Minimum Replicas |
+	| :---: | :--- | :------ | :--- | :--------------- |
+	| ❌ | bad-dpl | deployment | Deployment | 1 |
+	| ❌ | coredns | kube-system | Deployment | 2 |
+	| ❌ | bad-ss | statefulset | StatefulSet | 1 |
+
+
+
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
 
 3. Verify that there is sufficient IP space available to the pods running in the cluster when using custom networking. With the in-place, surge upgrade process, there will be higher IP consumption during the upgrade.
@@ -247,7 +256,7 @@ The default update strategy for EKS managed nodegroups is a surge, rolling updat
     Check [[EKS006]](https://clowdhaus.github.io/eksup/process/checks/#eks006)
 	|   -   | MNG Name  | Launch Template ID | Current | Latest |
 	| :---: | :-------- | :----------------- | :-----: | :----: |
-	| ⚠️ | `standard-2023020223592170250000002d` | `lt-066f4621afc89c753` | `1` | `2` |
+	| ⚠️ | `standard-2023012520034032750000002d` | `lt-06aa285a3b55fa0b6` | `1` | `2` |
 
 
 ##### Upgrade
@@ -323,7 +332,7 @@ A starting point for the instance refresh configuration is to use a value of 70%
     Check [[EKS007]](https://clowdhaus.github.io/eksup/process/checks/#eks007)
 	|   -   | ASG Name | Launch Template ID | Current | Latest |
 	| :---: | :------- | :----------------- | :-----: | :----: |
-	| ⚠️ | `different-20230202235921829700000031` | `lt-0105b5eee96aa8737` | `1` | `2` |
+	| ⚠️ | `different-20230125200340605200000031` | `lt-00c9c5fd3111c1e01` | `1` | `2` |
 
 
 ##### Upgrade


### PR DESCRIPTION
## Description
- Add support for reporting on Kubernetes workload resource findings for min replicas and `minReadySeconds`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves #

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
