### PR TITLE
feat: Add formatting for CLI stdout output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +734,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.17",
+ "tabled",
  "tokio",
  "tracing",
 ]
@@ -1424,6 +1431,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
+name = "papergrid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1526bb6aa9f10ec339fb10360f22c57edf81d5678d0278e93bc12a47ffbe4b01"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,6 +2026,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tabled"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c3ee73732ffceaea7b8f6b719ce3bb17f253fa27461ffeaf568ebd0cdb4b85"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beca1b4eaceb4f2755df858b88d9b9315b7ccfd1ffd0d7a48a52602301f01a57"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/eksup/Cargo.toml
+++ b/eksup/Cargo.toml
@@ -42,5 +42,6 @@ seq-macro = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+tabled = "0.10"
 tokio = { version = "1.23", features = ["full"] }
 tracing = "0.1"

--- a/eksup/src/analysis.rs
+++ b/eksup/src/analysis.rs
@@ -19,18 +19,19 @@ impl Results {
   pub(crate) fn to_stdout_table(&self) -> Result<String> {
     let mut output = String::new();
 
+    // Ordered sub-group (AWS -> EKS -> K8s) and check number
+    output.push_str(&self.subnets.pod_ips.to_stdout_table()?);
+    output.push_str(&self.subnets.control_plane_ips.to_stdout_table()?);
     output.push_str(&self.cluster.cluster_health.to_stdout_table()?);
 
-    output.push_str(&self.subnets.control_plane_ips.to_stdout_table()?);
-    output.push_str(&self.subnets.pod_ips.to_stdout_table()?);
-
-    output.push_str(&self.data_plane.version_skew.to_stdout_table()?);
     output.push_str(&self.data_plane.eks_managed_nodegroup_health.to_stdout_table()?);
+    output.push_str(&self.addons.health.to_stdout_table()?);
+    output.push_str(&self.addons.version_compatibility.to_stdout_table()?);
+
     output.push_str(&self.data_plane.eks_managed_nodegroup_update.to_stdout_table()?);
     output.push_str(&self.data_plane.self_managed_nodegroup_update.to_stdout_table()?);
 
-    output.push_str(&self.addons.health.to_stdout_table()?);
-    output.push_str(&self.addons.version_compatibility.to_stdout_table()?);
+    output.push_str(&self.data_plane.version_skew.to_stdout_table()?);
     output.push_str(&self.kubernetes.min_replicas.to_stdout_table()?);
     output.push_str(&self.kubernetes.min_ready_seconds.to_stdout_table()?);
 

--- a/eksup/src/analysis.rs
+++ b/eksup/src/analysis.rs
@@ -20,8 +20,15 @@ impl Results {
     let mut output = String::new();
 
     output.push_str(&self.cluster.cluster_health.to_stdout_table()?);
+
     output.push_str(&self.subnets.control_plane_ips.to_stdout_table()?);
-    // output.push_str(&self.data_plane..to_stdout_table()?);
+    output.push_str(&self.subnets.pod_ips.to_stdout_table()?);
+
+    output.push_str(&self.data_plane.version_skew.to_stdout_table()?);
+    output.push_str(&self.data_plane.eks_managed_nodegroup_health.to_stdout_table()?);
+    output.push_str(&self.data_plane.eks_managed_nodegroup_update.to_stdout_table()?);
+    output.push_str(&self.data_plane.self_managed_nodegroup_update.to_stdout_table()?);
+
     output.push_str(&self.addons.health.to_stdout_table()?);
     output.push_str(&self.addons.version_compatibility.to_stdout_table()?);
     output.push_str(&self.kubernetes.min_replicas.to_stdout_table()?);

--- a/eksup/src/eks/checks.rs
+++ b/eksup/src/eks/checks.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use anyhow::Result;
 use aws_sdk_autoscaling::model::AutoScalingGroup;
 use aws_sdk_ec2::Client as Ec2Client;
@@ -9,7 +7,7 @@ use aws_sdk_eks::{
 };
 use kube::Client as K8sClient;
 use serde::{Deserialize, Serialize};
-use tabled::{Style, Table, Tabled};
+use tabled::{locator::ByColumnName, Disable, Margin, Style, Table, Tabled};
 
 use crate::{
   eks::resources,
@@ -24,9 +22,8 @@ use crate::{
 /// Nearly identical to the SDK's `ClusterIssue` but allows us to serialize/deserialize
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 pub struct ClusterHealthIssue {
-  #[tabled(rename = "CHECK")]
-  pub fcode: finding::Code,
-  pub remediation: finding::Remediation,
+  #[tabled(inline)]
+  pub finding: finding::Finding,
   pub code: String,
   pub message: String,
   #[tabled(display_with = "tabled_vec_to_string")]
@@ -34,38 +31,19 @@ pub struct ClusterHealthIssue {
 }
 
 impl Findings for Vec<ClusterHealthIssue> {
-  fn to_markdown_table(&self, leading_whitespace: &str) -> Option<String> {
+  fn to_markdown_table(&self, leading_whitespace: &str) -> Result<String> {
     if self.is_empty() {
-      return Some(format!(
+      return Ok(format!(
         "{leading_whitespace}✅ - There are no reported health issues on the cluster control plane"
       ));
     }
 
-    let mut table = String::new();
-    table.push_str(&format!(
-      "{leading_whitespace}|   _   | Code  | Message | Resource IDs |\n"
-    ));
-    table.push_str(&format!(
-      "{leading_whitespace}| :---: | :---: | :------ | :----------- |\n"
-    ));
+    let mut table = Table::new(self);
+    table
+      .with(Margin::new(1, 0, 0, 0).set_fill('\t', 'x', 'x', 'x'))
+      .with(Style::markdown());
 
-    for finding in self {
-      table.push_str(&format!(
-        "{}| {} | `{}` | `{}` | {} |\n",
-        leading_whitespace,
-        finding.remediation.symbol(),
-        finding.code,
-        finding.message,
-        finding
-          .resource_ids
-          .iter()
-          .map(|f| format!("`{f}`"))
-          .collect::<Vec<String>>()
-          .join(", "),
-      ))
-    }
-
-    Some(table)
+    Ok(format!("{table}\n"))
   }
 
   fn to_stdout_table(&self) -> Result<String> {
@@ -94,12 +72,18 @@ pub(crate) async fn cluster_health(cluster: &Cluster) -> Result<Vec<ClusterHealt
         .map(|issue| {
           let code = &issue.code().unwrap().to_owned();
 
+          let remediation = finding::Remediation::Required;
+          let finding = finding::Finding {
+            code: finding::Code::EKS002,
+            symbol: remediation.symbol(),
+            remediation,
+          };
+
           ClusterHealthIssue {
+            finding,
             code: code.as_str().to_string(),
             message: issue.message().unwrap().to_string(),
             resource_ids: issue.resource_ids().unwrap().to_owned(),
-            remediation: finding::Remediation::Required,
-            fcode: finding::Code::EKS002,
           }
         })
         .collect();
@@ -114,41 +98,26 @@ pub(crate) async fn cluster_health(cluster: &Cluster) -> Result<Vec<ClusterHealt
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
 pub struct InsufficientSubnetIps {
-  #[tabled(rename = "CHECK")]
-  pub fcode: finding::Code,
-  pub remediation: finding::Remediation,
+  #[tabled(inline)]
+  pub finding: finding::Finding,
   #[tabled(display_with = "tabled_vec_to_string")]
   pub ids: Vec<String>,
   pub available_ips: i32,
 }
 
 impl Findings for Option<InsufficientSubnetIps> {
-  fn to_markdown_table(&self, leading_whitespace: &str) -> Option<String> {
+  fn to_markdown_table(&self, leading_whitespace: &str) -> Result<String> {
     match self {
       Some(finding) => {
-        let mut table = String::new();
-        table.push_str(&format!(
-          "{leading_whitespace}|   -   | Subnet IDs  | Available IPs |\n"
-        ));
-        table.push_str(&format!(
-          "{leading_whitespace}| :---: | :---------- | :-----------: |\n"
-        ));
-        table.push_str(&format!(
-          "{}| {} | {} | `{}` |\n",
-          leading_whitespace,
-          finding.remediation.symbol(),
-          finding
-            .ids
-            .iter()
-            .map(|f| format!("`{f}`"))
-            .collect::<Vec<String>>()
-            .join(", "),
-          finding.available_ips,
-        ));
+        let mut table = Table::new(vec![finding]);
+        table
+          .with(Disable::column(ByColumnName::new("CHECK")))
+          .with(Margin::new(1, 0, 0, 0).set_fill('\t', 'x', 'x', 'x'))
+          .with(Style::markdown());
 
-        Some(table)
+        Ok(format!("{table}\n"))
       }
-      None => Some(format!(
+      None => Ok(format!(
         "{leading_whitespace}✅ - There is sufficient IP space in the subnets provided"
       )),
     }
@@ -178,11 +147,17 @@ pub(crate) async fn control_plane_ips(
     return Ok(None);
   }
 
+  let remediation = finding::Remediation::Required;
+  let finding = finding::Finding {
+    code: finding::Code::EKS001,
+    symbol: remediation.symbol(),
+    remediation,
+  };
+
   let finding = InsufficientSubnetIps {
+    finding,
     ids: subnet_ips.ids,
     available_ips: subnet_ips.available_ips,
-    remediation: finding::Remediation::Required,
-    fcode: finding::Code::EKS001,
   };
 
   Ok(Some(finding))
@@ -220,71 +195,20 @@ pub(crate) async fn pod_ips(
   } else {
     finding::Remediation::Recommended
   };
-  let finding = InsufficientSubnetIps {
-    ids: subnet_ips.ids,
-    available_ips: subnet_ips.available_ips,
+
+  let finding = finding::Finding {
+    code: finding::Code::AWS002,
+    symbol: remediation.symbol(),
     remediation,
-    fcode: finding::Code::AWS002,
   };
 
-  Ok(Some(finding))
-}
+  let subnetips = InsufficientSubnetIps {
+    finding,
+    ids: subnet_ips.ids,
+    available_ips: subnet_ips.available_ips,
+  };
 
-#[derive(Debug, Serialize, Deserialize, Tabled)]
-#[tabled(rename_all = "UpperCase")]
-pub struct AddonVersion {
-  /// Latest supported version of the addon
-  pub latest: String,
-  /// Default version of the addon used by the service
-  pub default: String,
-  /// Supported versions for the given Kubernetes version
-  /// This maintains the ordering of latest version to oldest
-  #[tabled(skip)]
-  pub supported_versions: HashSet<String>,
-}
-
-/// Get the addon version details for the given addon and Kubernetes version
-///
-/// Returns associated version details for a given addon that, primarily used
-/// for version compatibility checks and/or upgrade recommendations
-async fn get_addon_versions(client: &EksClient, name: &str, kubernetes_version: &str) -> Result<AddonVersion> {
-  // Get all of the addon versions supported for the given addon and Kubernetes version
-  let describe = client
-    .describe_addon_versions()
-    .addon_name(name)
-    .kubernetes_version(kubernetes_version)
-    .send()
-    .await?;
-
-  // Since we are providing an addon name, we are only concerned with the first and only item
-  let addon = describe.addons().unwrap().get(0).unwrap();
-  let addon_version = addon.addon_versions().unwrap();
-  let latest_version = addon_version.first().unwrap().addon_version().unwrap();
-
-  // The default version as specified by the EKS API for a given addon and Kubernetes version
-  let default_version = addon
-    .addon_versions()
-    .unwrap()
-    .iter()
-    .filter(|v| v.compatibilities().unwrap().iter().any(|c| c.default_version))
-    .map(|v| v.addon_version().unwrap())
-    .next()
-    .unwrap();
-
-  // Get the list of ALL supported version for this addon and Kubernetes version
-  // The results maintain the oder of latest version to oldest
-  let supported_versions: HashSet<String> = addon
-    .addon_versions()
-    .unwrap()
-    .iter()
-    .map(|v| v.addon_version().unwrap().to_owned())
-    .collect();
-
-  Ok(AddonVersion {
-    latest: latest_version.to_owned(),
-    default: default_version.to_owned(),
-    supported_versions,
-  })
+  Ok(Some(subnetips))
 }
 
 /// Details of the addon as viewed from an upgrade perspective
@@ -299,50 +223,35 @@ async fn get_addon_versions(client: &EksClient, name: &str, kubernetes_version: 
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
 pub struct AddonVersionCompatibility {
-  #[tabled(rename = "CHECK")]
-  pub fcode: finding::Code,
-  pub remediation: finding::Remediation,
+  #[tabled(inline)]
+  pub finding: finding::Finding,
   pub name: String,
   /// The current version of the add-on
   #[tabled(rename = "CURRENT")]
   pub version: String,
   /// The default and latest add-on versions for the current Kubernetes version
   #[tabled(skip)]
-  pub current_kubernetes_version: AddonVersion,
+  pub current_kubernetes_version: resources::AddonVersion,
   /// The default and latest add-on versions for the target Kubernetes version
   #[tabled(inline)]
-  pub target_kubernetes_version: AddonVersion,
+  pub target_kubernetes_version: resources::AddonVersion,
 }
 
 impl Findings for Vec<AddonVersionCompatibility> {
-  fn to_markdown_table(&self, leading_whitespace: &str) -> Option<String> {
+  fn to_markdown_table(&self, leading_whitespace: &str) -> Result<String> {
     if self.is_empty() {
-      return Some(format!(
+      return Ok(format!(
         "{leading_whitespace}✅ - There are no reported addon version compatibility issues."
       ));
     }
 
-    let mut table = String::new();
-    table.push_str(&format!(
-      "{leading_whitespace}|   -   | Name  | Version | Next Default | Next Latest |\n"
-    ));
-    table.push_str(&format!(
-      "{leading_whitespace}| :---: | :---- | :-----: | :----------: | :---------: |\n"
-    ));
+    let mut table = Table::new(self);
+    table
+      .with(Disable::column(ByColumnName::new("CHECK")))
+      .with(Margin::new(1, 0, 0, 0).set_fill('\t', 'x', 'x', 'x'))
+      .with(Style::markdown());
 
-    for finding in self {
-      table.push_str(&format!(
-        "{}| {} | `{}` | `{}` | `{}` | `{}` |\n",
-        leading_whitespace,
-        finding.remediation.symbol(),
-        finding.name,
-        finding.version,
-        finding.target_kubernetes_version.default,
-        finding.target_kubernetes_version.latest,
-      ))
-    }
-
-    Some(table)
+    Ok(format!("{table}\n"))
   }
 
   fn to_stdout_table(&self) -> Result<String> {
@@ -370,8 +279,8 @@ pub(crate) async fn addon_version_compatibility(
     let name = addon.addon_name().unwrap().to_owned();
     let version = addon.addon_version().unwrap().to_owned();
 
-    let current_kubernetes_version = get_addon_versions(client, &name, cluster_version).await?;
-    let target_kubernetes_version = get_addon_versions(client, &name, &target_k8s_version).await?;
+    let current_kubernetes_version = resources::get_addon_versions(client, &name, cluster_version).await?;
+    let target_kubernetes_version = resources::get_addon_versions(client, &name, &target_k8s_version).await?;
 
     // TODO - why is this saying the if/else is the same?
     #[allow(clippy::if_same_then_else)]
@@ -389,13 +298,18 @@ pub(crate) async fn addon_version_compatibility(
     };
 
     if let Some(remediation) = remediation {
+      let finding = finding::Finding {
+        code: finding::Code::EKS005,
+        symbol: remediation.symbol(),
+        remediation,
+      };
+
       addon_versions.push(AddonVersionCompatibility {
+        finding,
         name,
         version,
         current_kubernetes_version,
         target_kubernetes_version,
-        remediation,
-        fcode: finding::Code::EKS005,
       })
     }
   }
@@ -409,9 +323,8 @@ pub(crate) async fn addon_version_compatibility(
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
 pub struct AddonHealthIssue {
-  #[tabled(rename = "CHECK")]
-  pub fcode: finding::Code,
-  pub remediation: finding::Remediation,
+  #[tabled(inline)]
+  pub finding: finding::Finding,
   pub name: String,
   pub code: String,
   pub message: String,
@@ -420,39 +333,20 @@ pub struct AddonHealthIssue {
 }
 
 impl Findings for Vec<AddonHealthIssue> {
-  fn to_markdown_table(&self, leading_whitespace: &str) -> Option<String> {
+  fn to_markdown_table(&self, leading_whitespace: &str) -> Result<String> {
     if self.is_empty() {
-      return Some(format!(
+      return Ok(format!(
         "{leading_whitespace}✅ - There are no reported addon health issues."
       ));
     }
 
-    let mut table = String::new();
-    table.push_str(&format!(
-      "{leading_whitespace}|   -   | Name  | Code  | Message | Resource IDs |\n"
-    ));
-    table.push_str(&format!(
-      "{leading_whitespace}| :---: | :---- | :---: | :------ | :----------- |\n"
-    ));
+    let mut table = Table::new(self);
+    table
+      .with(Disable::column(ByColumnName::new("CHECK")))
+      .with(Margin::new(1, 0, 0, 0).set_fill('\t', 'x', 'x', 'x'))
+      .with(Style::markdown());
 
-    for finding in self {
-      table.push_str(&format!(
-        "{}| {} | `{}` | `{}` | `{}` | {} |\n",
-        leading_whitespace,
-        finding.remediation.symbol(),
-        finding.name,
-        finding.code,
-        finding.message,
-        finding
-          .resource_ids
-          .iter()
-          .map(|f| format!("`{f}`"))
-          .collect::<Vec<String>>()
-          .join(", "),
-      ))
-    }
-
-    Some(table)
+    Ok(format!("{table}\n"))
   }
 
   fn to_stdout_table(&self) -> Result<String> {
@@ -481,13 +375,19 @@ pub(crate) async fn addon_health(addons: &[Addon]) -> Result<Vec<AddonHealthIssu
         .map(|issue| {
           let code = issue.code().unwrap();
 
+          let remediation = finding::Remediation::Required;
+          let finding = finding::Finding {
+            code: finding::Code::EKS004,
+            symbol: remediation.symbol(),
+            remediation,
+          };
+
           AddonHealthIssue {
+            finding,
             name: name.to_owned(),
             code: code.as_str().to_string(),
             message: issue.message().unwrap().to_owned(),
             resource_ids: issue.resource_ids().unwrap().to_owned(),
-            remediation: finding::Remediation::Required,
-            fcode: finding::Code::EKS004,
           }
         })
         .collect::<Vec<AddonHealthIssue>>()
@@ -504,38 +404,28 @@ pub(crate) async fn addon_health(addons: &[Addon]) -> Result<Vec<AddonHealthIssu
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
 pub struct NodegroupHealthIssue {
-  #[tabled(rename = "CHECK")]
-  pub fcode: finding::Code,
-  pub remediation: finding::Remediation,
+  #[tabled(inline)]
+  pub finding: finding::Finding,
   pub name: String,
   pub code: String,
   pub message: String,
 }
 
 impl Findings for Vec<NodegroupHealthIssue> {
-  fn to_markdown_table(&self, leading_whitespace: &str) -> Option<String> {
+  fn to_markdown_table(&self, leading_whitespace: &str) -> Result<String> {
     if self.is_empty() {
-      return Some(format!(
+      return Ok(format!(
         "{leading_whitespace}✅ - There are no reported nodegroup health issues."
       ));
     }
 
-    let mut table = String::new();
-    table.push_str(&format!("{leading_whitespace}|   -   | Name  | Code  | Message |\n"));
-    table.push_str(&format!("{leading_whitespace}| :---: | :---- | :---: | :------ |\n"));
+    let mut table = Table::new(self);
+    table
+      .with(Disable::column(ByColumnName::new("CHECK")))
+      .with(Margin::new(1, 0, 0, 0).set_fill('\t', 'x', 'x', 'x'))
+      .with(Style::markdown());
 
-    for finding in self {
-      table.push_str(&format!(
-        "{}| {} | `{}` | `{}` | `{}` |\n",
-        leading_whitespace,
-        finding.remediation.symbol(),
-        finding.name,
-        finding.code,
-        finding.message,
-      ))
-    }
-
-    Some(table)
+    Ok(format!("{table}\n"))
   }
 
   fn to_stdout_table(&self) -> Result<String> {
@@ -563,12 +453,18 @@ pub(crate) async fn eks_managed_nodegroup_health(nodegroups: &[Nodegroup]) -> Re
         let code = issue.code().unwrap();
         let message = issue.message().unwrap();
 
+        let remediation = finding::Remediation::Required;
+        let finding = finding::Finding {
+          code: finding::Code::EKS003,
+          symbol: remediation.symbol(),
+          remediation,
+        };
+
         NodegroupHealthIssue {
+          finding,
           name: name.to_owned(),
           code: code.as_str().to_owned(),
           message: message.to_owned(),
-          remediation: finding::Remediation::Required,
-          fcode: finding::Code::EKS003,
         }
       })
     })
@@ -580,9 +476,8 @@ pub(crate) async fn eks_managed_nodegroup_health(nodegroups: &[Nodegroup]) -> Re
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
 pub struct ManagedNodeGroupUpdate {
-  #[tabled(rename = "CHECK")]
-  pub fcode: finding::Code,
-  pub remediation: finding::Remediation,
+  #[tabled(inline)]
+  pub finding: finding::Finding,
   /// EKS managed node group name
   #[tabled(rename = "MANAGED NODEGROUP")]
   pub name: String,
@@ -602,34 +497,20 @@ pub struct ManagedNodeGroupUpdate {
 }
 
 impl Findings for Vec<ManagedNodeGroupUpdate> {
-  fn to_markdown_table(&self, leading_whitespace: &str) -> Option<String> {
+  fn to_markdown_table(&self, leading_whitespace: &str) -> Result<String> {
     if self.is_empty() {
-      return Some(format!(
+      return Ok(format!(
         "{leading_whitespace}✅ - There are no pending updates for the EKS managed nodegroup(s)"
       ));
     }
 
-    let mut table = String::new();
-    table.push_str(&format!(
-      "{leading_whitespace}|   -   | MNG Name  | Launch Template ID | Current | Latest |\n"
-    ));
-    table.push_str(&format!(
-      "{leading_whitespace}| :---: | :-------- | :----------------- | :-----: | :----: |\n"
-    ));
+    let mut table = Table::new(self);
+    table
+      .with(Disable::column(ByColumnName::new("CHECK")))
+      .with(Margin::new(1, 0, 0, 0).set_fill('\t', 'x', 'x', 'x'))
+      .with(Style::markdown());
 
-    for finding in self {
-      table.push_str(&format!(
-        "{}| {} | `{}` | `{}` | `{}` | `{}` |\n",
-        leading_whitespace,
-        finding.remediation.symbol(),
-        finding.name,
-        finding.launch_template.id,
-        finding.launch_template.current_version,
-        finding.launch_template.latest_version,
-      ))
-    }
-
-    Some(table)
+    Ok(format!("{table}\n"))
   }
 
   fn to_stdout_table(&self) -> Result<String> {
@@ -667,12 +548,20 @@ pub(crate) async fn eks_managed_nodegroup_update(
         .auto_scaling_groups()
         .unwrap()
         .iter()
-        .map(|asg| ManagedNodeGroupUpdate {
-          name: nodegroup.nodegroup_name().unwrap().to_owned(),
-          autoscaling_group_name: asg.name().unwrap().to_owned(),
-          launch_template: launch_template.to_owned(),
-          remediation: finding::Remediation::Recommended,
-          fcode: finding::Code::EKS006,
+        .map(|asg| {
+          let remediation = finding::Remediation::Recommended;
+          let finding = finding::Finding {
+            code: finding::Code::EKS006,
+            symbol: remediation.symbol(),
+            remediation,
+          };
+
+          ManagedNodeGroupUpdate {
+            finding,
+            name: nodegroup.nodegroup_name().unwrap().to_owned(),
+            autoscaling_group_name: asg.name().unwrap().to_owned(),
+            launch_template: launch_template.to_owned(),
+          }
         })
         // Only interested in those that are not using the latest version
         .filter(|asg| asg.launch_template.current_version != asg.launch_template.latest_version)
@@ -686,9 +575,8 @@ pub(crate) async fn eks_managed_nodegroup_update(
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
 pub struct AutoscalingGroupUpdate {
-  #[tabled(rename = "CHECK")]
-  pub fcode: finding::Code,
-  pub remediation: finding::Remediation,
+  #[tabled(inline)]
+  pub finding: finding::Finding,
   /// Autoscaling group name
   #[tabled(rename = "AUTOSCALING GROUP")]
   pub name: String,
@@ -702,34 +590,20 @@ pub struct AutoscalingGroupUpdate {
 }
 
 impl Findings for Vec<AutoscalingGroupUpdate> {
-  fn to_markdown_table(&self, leading_whitespace: &str) -> Option<String> {
+  fn to_markdown_table(&self, leading_whitespace: &str) -> Result<String> {
     if self.is_empty() {
-      return Some(format!(
+      return Ok(format!(
         "{leading_whitespace}✅ - There are no pending updates for the self-managed nodegroup(s)"
       ));
     }
 
-    let mut table = String::new();
-    table.push_str(&format!(
-      "{leading_whitespace}|   -   | ASG Name | Launch Template ID | Current | Latest |\n"
-    ));
-    table.push_str(&format!(
-      "{leading_whitespace}| :---: | :------- | :----------------- | :-----: | :----: |\n"
-    ));
+    let mut table = Table::new(self);
+    table
+      .with(Disable::column(ByColumnName::new("CHECK")))
+      .with(Margin::new(1, 0, 0, 0).set_fill('\t', 'x', 'x', 'x'))
+      .with(Style::markdown());
 
-    for finding in self {
-      table.push_str(&format!(
-        "{}| {} | `{}` | `{}` | `{}` | `{}` |\n",
-        leading_whitespace,
-        finding.remediation.symbol(),
-        finding.name,
-        finding.launch_template.id,
-        finding.launch_template.current_version,
-        finding.launch_template.latest_version,
-      ))
-    }
-
-    Some(table)
+    Ok(format!("{table}\n"))
   }
 
   fn to_stdout_table(&self) -> Result<String> {
@@ -764,11 +638,17 @@ pub(crate) async fn self_managed_nodegroup_update(
 
   // Only interested in those that are not using the latest version
   if launch_template.current_version != launch_template.latest_version {
+    let remediation = finding::Remediation::Recommended;
+    let finding = finding::Finding {
+      code: finding::Code::EKS007,
+      symbol: remediation.symbol(),
+      remediation,
+    };
+
     let update = AutoscalingGroupUpdate {
+      finding,
       name,
       launch_template,
-      remediation: finding::Remediation::Recommended,
-      fcode: finding::Code::EKS007,
     };
     Ok(Some(update))
   } else {

--- a/eksup/src/eks/checks.rs
+++ b/eksup/src/eks/checks.rs
@@ -9,7 +9,7 @@ use aws_sdk_eks::{
 };
 use kube::Client as K8sClient;
 use serde::{Deserialize, Serialize};
-use tabled::{format::Format, object::Rows, Modify, Style, Table, Tabled};
+use tabled::{Style, Table, Tabled};
 
 use crate::{
   eks::resources,
@@ -74,12 +74,9 @@ impl Findings for Vec<ClusterHealthIssue> {
     }
 
     let mut table = Table::new(self);
-    let style = Style::blank();
-    table
-      .with(style)
-      .with(Modify::new(Rows::first()).with(Format::new(|s| s.to_uppercase())));
+    table.with(Style::sharp());
 
-    Ok(table.to_string())
+    Ok(format!("{table}\n"))
   }
 }
 
@@ -162,9 +159,9 @@ impl Findings for Option<InsufficientSubnetIps> {
       None => Ok("".to_owned()),
       Some(finding) => {
         let mut table = Table::new(vec![finding]);
-        table.with(Style::blank());
+        table.with(Style::sharp());
 
-        Ok(table.to_string())
+        Ok(format!("{table}\n"))
       }
     }
   }
@@ -309,7 +306,7 @@ pub struct AddonVersionCompatibility {
   /// The current version of the add-on
   pub version: String,
   /// The default and latest add-on versions for the current Kubernetes version
-  #[tabled(inline)]
+  #[tabled(skip)]
   pub current_kubernetes_version: AddonVersion,
   /// The default and latest add-on versions for the target Kubernetes version
   #[tabled(inline)]
@@ -355,7 +352,7 @@ impl Findings for Vec<AddonVersionCompatibility> {
     let mut table = Table::new(self);
     table.with(Style::sharp());
 
-    Ok(format!("{}\n", table.to_string()))
+    Ok(format!("{table}\n"))
   }
 }
 
@@ -463,9 +460,9 @@ impl Findings for Vec<AddonHealthIssue> {
     }
 
     let mut table = Table::new(self);
-    table.with(Style::blank());
+    table.with(Style::sharp());
 
-    Ok(table.to_string())
+    Ok(format!("{table}\n"))
   }
 }
 
@@ -505,13 +502,13 @@ pub(crate) async fn addon_health(addons: &[Addon]) -> Result<Vec<AddonHealthIssu
 /// and without `Option()`s to make it a bit more ergonomic here
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
-pub(crate) struct NodegroupHealthIssue {
+pub struct NodegroupHealthIssue {
   #[tabled(rename = "CHECK")]
-  pub(crate) fcode: finding::Code,
-  pub(crate) remediation: finding::Remediation,
-  pub(crate) name: String,
-  pub(crate) code: String,
-  pub(crate) message: String,
+  pub fcode: finding::Code,
+  pub remediation: finding::Remediation,
+  pub name: String,
+  pub code: String,
+  pub message: String,
 }
 
 impl Findings for Vec<NodegroupHealthIssue> {
@@ -546,9 +543,9 @@ impl Findings for Vec<NodegroupHealthIssue> {
     }
 
     let mut table = Table::new(self);
-    table.with(Style::blank());
+    table.with(Style::sharp());
 
-    Ok(table.to_string())
+    Ok(format!("{table}\n"))
   }
 }
 
@@ -581,20 +578,20 @@ pub(crate) async fn eks_managed_nodegroup_health(nodegroups: &[Nodegroup]) -> Re
 
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
-pub(crate) struct ManagedNodeGroupUpdate {
+pub struct ManagedNodeGroupUpdate {
   #[tabled(rename = "CHECK")]
-  pub(crate) fcode: finding::Code,
-  pub(crate) remediation: finding::Remediation,
+  pub fcode: finding::Code,
+  pub remediation: finding::Remediation,
   /// EKS managed node group name
-  pub(crate) name: String,
+  pub name: String,
   /// Name of the autoscaling group associated to the EKS managed node group
-  pub(crate) autoscaling_group_name: String,
+  pub autoscaling_group_name: String,
   /// Launch template controlled by users that influences the autoscaling group
   ///
   /// This distinction is important because we only consider the launch templates
   /// provided by users and not provided by EKS managed node group(s)
   #[tabled(inline)]
-  pub(crate) launch_template: resources::LaunchTemplate,
+  pub launch_template: resources::LaunchTemplate,
   // We do not consider launch configurations because you cannot determine if any
   // updates are pending like with launch templates and because they are being deprecated
   // https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html
@@ -638,9 +635,9 @@ impl Findings for Vec<ManagedNodeGroupUpdate> {
     }
 
     let mut table = Table::new(self);
-    table.with(Style::blank());
+    table.with(Style::sharp());
 
-    Ok(table.to_string())
+    Ok(format!("{table}\n"))
   }
 }
 
@@ -685,15 +682,15 @@ pub(crate) async fn eks_managed_nodegroup_update(
 
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
-pub(crate) struct AutoscalingGroupUpdate {
+pub struct AutoscalingGroupUpdate {
   #[tabled(rename = "CHECK")]
-  pub(crate) fcode: finding::Code,
-  pub(crate) remediation: finding::Remediation,
+  pub fcode: finding::Code,
+  pub remediation: finding::Remediation,
   /// Autoscaling group name
-  pub(crate) name: String,
+  pub name: String,
   /// Launch template used by the autoscaling group
   #[tabled(inline)]
-  pub(crate) launch_template: resources::LaunchTemplate,
+  pub launch_template: resources::LaunchTemplate,
   // We do not consider launch configurations because you cannot determine if any
   // updates are pending like with launch templates and because they are being deprecated
   // https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html
@@ -737,9 +734,9 @@ impl Findings for Vec<AutoscalingGroupUpdate> {
     }
 
     let mut table = Table::new(self);
-    table.with(Style::blank());
+    table.with(Style::sharp());
 
-    Ok(table.to_string())
+    Ok(format!("{table}\n"))
   }
 }
 

--- a/eksup/src/eks/checks.rs
+++ b/eksup/src/eks/checks.rs
@@ -304,6 +304,7 @@ pub struct AddonVersionCompatibility {
   pub remediation: finding::Remediation,
   pub name: String,
   /// The current version of the add-on
+  #[tabled(rename = "CURRENT")]
   pub version: String,
   /// The default and latest add-on versions for the current Kubernetes version
   #[tabled(skip)]
@@ -583,8 +584,10 @@ pub struct ManagedNodeGroupUpdate {
   pub fcode: finding::Code,
   pub remediation: finding::Remediation,
   /// EKS managed node group name
+  #[tabled(rename = "MANAGED NODEGROUP")]
   pub name: String,
   /// Name of the autoscaling group associated to the EKS managed node group
+  #[tabled(skip)]
   pub autoscaling_group_name: String,
   /// Launch template controlled by users that influences the autoscaling group
   ///
@@ -687,6 +690,7 @@ pub struct AutoscalingGroupUpdate {
   pub fcode: finding::Code,
   pub remediation: finding::Remediation,
   /// Autoscaling group name
+  #[tabled(rename = "AUTOSCALING GROUP")]
   pub name: String,
   /// Launch template used by the autoscaling group
   #[tabled(inline)]

--- a/eksup/src/eks/findings.rs
+++ b/eksup/src/eks/findings.rs
@@ -5,7 +5,6 @@ use aws_sdk_eks::{model::Cluster, Client as EksClient};
 use kube::Client as K8sClient;
 use serde::{Deserialize, Serialize};
 
-use super::checks::AutoscalingGroupUpdate;
 use crate::{
   eks::{checks, resources},
   k8s,
@@ -109,7 +108,7 @@ pub struct DataPlaneFindings {
   /// (i.e. - any changes that may have been introduced in the launch template versions that have not been deployed)
   pub eks_managed_nodegroup_update: Vec<checks::ManagedNodeGroupUpdate>,
   /// Similar to the `eks_managed_nodegroup_update` except for self-managed node groups (autoscaling groups)
-  pub self_managed_nodegroup_update: Vec<AutoscalingGroupUpdate>,
+  pub self_managed_nodegroup_update: Vec<checks::AutoscalingGroupUpdate>,
 
   /// The names of the EKS managed node groups
   pub eks_managed_nodegroups: Vec<String>,

--- a/eksup/src/eks/findings.rs
+++ b/eksup/src/eks/findings.rs
@@ -100,7 +100,7 @@ pub struct DataPlaneFindings {
   /// It is recommended that these versions are aligned prior to upgrading, and changes are required when
   /// the skew policy could be violated post upgrade (i.e. if current skew is +2, the policy would be violated
   /// as soon as the control plane is upgraded, resulting in +3, and therefore changes are required before upgrade)
-  pub version_skew: Vec<k8s::NodeFinding>,
+  pub version_skew: Vec<k8s::VersionSkew>,
   /// The health of the EKS managed node groups as reported by the Amazon EKS managed node group API
   pub eks_managed_nodegroup_health: Vec<checks::NodegroupHealthIssue>,
   /// Will show if the current launch template provided to the Amazon EKS managed node group is NOT the latest

--- a/eksup/src/eks/resources.rs
+++ b/eksup/src/eks/resources.rs
@@ -201,12 +201,16 @@ pub async fn get_fargate_profiles(client: &EksClient, cluster_name: &str) -> Res
 #[tabled(rename_all = "UpperCase")]
 pub struct LaunchTemplate {
   /// Name of the launch template
+  #[tabled(skip)]
   pub name: String,
   /// The ID of the launch template
+  #[tabled(rename = "LAUNCH TEMP ID")]
   pub id: String,
   /// The version of the launch template currently used/specified in the autoscaling group
+  #[tabled(rename = "CURRENT")]
   pub current_version: String,
   /// The latest version of the launch template
+  #[tabled(rename = "LATEST")]
   pub latest_version: String,
 }
 

--- a/eksup/src/eks/resources.rs
+++ b/eksup/src/eks/resources.rs
@@ -13,6 +13,7 @@ use aws_sdk_eks::{
 };
 use aws_types::region::Region;
 use serde::{Deserialize, Serialize};
+use tabled::Tabled;
 
 /// Get the configuration to authn/authz with AWS that will be used across AWS clients
 pub async fn get_config(region: &Option<String>) -> Result<aws_config::SdkConfig> {
@@ -196,7 +197,8 @@ pub async fn get_fargate_profiles(client: &EksClient, cluster_name: &str) -> Res
   Ok(profiles)
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Tabled)]
+#[tabled(rename_all = "UpperCase")]
 pub struct LaunchTemplate {
   /// Name of the launch template
   pub name: String,

--- a/eksup/src/eks/resources.rs
+++ b/eksup/src/eks/resources.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{collections::HashSet, env};
 
 use anyhow::{bail, Result};
 use aws_config::meta::region::RegionProviderChain;
@@ -101,6 +101,67 @@ pub async fn get_addons(client: &EksClient, cluster_name: &str) -> Result<Vec<Ad
   }
 
   Ok(addons)
+}
+
+#[derive(Debug, Serialize, Deserialize, Tabled)]
+#[tabled(rename_all = "UpperCase")]
+pub struct AddonVersion {
+  /// Latest supported version of the addon
+  pub latest: String,
+  /// Default version of the addon used by the service
+  pub default: String,
+  /// Supported versions for the given Kubernetes version
+  /// This maintains the ordering of latest version to oldest
+  #[tabled(skip)]
+  pub supported_versions: HashSet<String>,
+}
+
+/// Get the addon version details for the given addon and Kubernetes version
+///
+/// Returns associated version details for a given addon that, primarily used
+/// for version compatibility checks and/or upgrade recommendations
+pub(crate) async fn get_addon_versions(
+  client: &EksClient,
+  name: &str,
+  kubernetes_version: &str,
+) -> Result<AddonVersion> {
+  // Get all of the addon versions supported for the given addon and Kubernetes version
+  let describe = client
+    .describe_addon_versions()
+    .addon_name(name)
+    .kubernetes_version(kubernetes_version)
+    .send()
+    .await?;
+
+  // Since we are providing an addon name, we are only concerned with the first and only item
+  let addon = describe.addons().unwrap().get(0).unwrap();
+  let addon_version = addon.addon_versions().unwrap();
+  let latest_version = addon_version.first().unwrap().addon_version().unwrap();
+
+  // The default version as specified by the EKS API for a given addon and Kubernetes version
+  let default_version = addon
+    .addon_versions()
+    .unwrap()
+    .iter()
+    .filter(|v| v.compatibilities().unwrap().iter().any(|c| c.default_version))
+    .map(|v| v.addon_version().unwrap())
+    .next()
+    .unwrap();
+
+  // Get the list of ALL supported version for this addon and Kubernetes version
+  // The results maintain the oder of latest version to oldest
+  let supported_versions: HashSet<String> = addon
+    .addon_versions()
+    .unwrap()
+    .iter()
+    .map(|v| v.addon_version().unwrap().to_owned())
+    .collect();
+
+  Ok(AddonVersion {
+    latest: latest_version.to_owned(),
+    default: default_version.to_owned(),
+    supported_versions,
+  })
 }
 
 pub async fn get_eks_managed_nodegroups(client: &EksClient, cluster_name: &str) -> Result<Vec<Nodegroup>> {

--- a/eksup/src/finding.rs
+++ b/eksup/src/finding.rs
@@ -1,12 +1,24 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use tabled::Tabled;
 
 use crate::version;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Tabled)]
+#[tabled(rename_all = "UpperCase")]
+pub struct Finding {
+  #[tabled(rename = "CHECK")]
+  pub code: Code,
+  #[tabled(rename = " ")]
+  pub symbol: String,
+  #[tabled(skip)]
+  pub remediation: Remediation,
+}
 
 /// Determines whether remediation is required or recommended
 ///
 /// This allows for filtering of findings shown to user
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Remediation {
   /// A finding that requires remediation prior to upgrading to be able to perform the upgrade
   /// and avoid downtime or disruption
@@ -18,10 +30,10 @@ pub enum Remediation {
 }
 
 impl Remediation {
-  pub(crate) fn symbol(&self) -> &'static str {
+  pub(crate) fn symbol(&self) -> String {
     match &self {
-      Remediation::Required => "❌",
-      Remediation::Recommended => "⚠️",
+      Remediation::Required => "❌".to_string(),
+      Remediation::Recommended => "⚠️".to_string(),
     }
   }
 }
@@ -36,7 +48,7 @@ impl std::fmt::Display for Remediation {
 }
 
 pub trait Findings {
-  fn to_markdown_table(&self, leading_whitespace: &str) -> Option<String>;
+  fn to_markdown_table(&self, leading_whitespace: &str) -> Result<String>;
   fn to_stdout_table(&self) -> Result<String>;
 }
 
@@ -63,7 +75,7 @@ pub(crate) trait Deprecation {
 /// to uniquely represent a finding even if the finding data is generic (i.e. - as is the case
 /// in reporting available IPs as subnet findings, the data shape is generic by the finding
 /// is unique to different scenarios)
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Code {
   /// AWS finding codes not specific to EKS
   ///

--- a/eksup/src/finding.rs
+++ b/eksup/src/finding.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::version;
@@ -25,8 +26,18 @@ impl Remediation {
   }
 }
 
+impl std::fmt::Display for Remediation {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    match *self {
+      Remediation::Required => write!(f, "Required"),
+      Remediation::Recommended => write!(f, "Recommended"),
+    }
+  }
+}
+
 pub trait Findings {
   fn to_markdown_table(&self, leading_whitespace: &str) -> Option<String>;
+  fn to_stdout_table(&self) -> Result<String>;
 }
 
 /// TODO - something is required to identify what Kubernetes resource findings are applicable
@@ -116,4 +127,30 @@ pub enum Code {
 
   /// `pod.spec.TerminationGracePeriodSeconds` is set to zero
   K8S007,
+}
+
+impl std::fmt::Display for Code {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    match *self {
+      Code::AWS001 => write!(f, "AWS001"),
+      Code::AWS002 => write!(f, "AWS002"),
+      Code::AWS003 => write!(f, "AWS003"),
+      Code::AWS004 => write!(f, "AWS004"),
+      Code::AWS005 => write!(f, "AWS005"),
+      Code::EKS001 => write!(f, "EKS001"),
+      Code::EKS002 => write!(f, "EKS002"),
+      Code::EKS003 => write!(f, "EKS003"),
+      Code::EKS004 => write!(f, "EKS004"),
+      Code::EKS005 => write!(f, "EKS005"),
+      Code::EKS006 => write!(f, "EKS006"),
+      Code::EKS007 => write!(f, "EKS007"),
+      Code::K8S001 => write!(f, "K8S001"),
+      Code::K8S002 => write!(f, "K8S002"),
+      Code::K8S003 => write!(f, "K8S003"),
+      Code::K8S004 => write!(f, "K8S004"),
+      Code::K8S005 => write!(f, "K8S005"),
+      Code::K8S006 => write!(f, "K8S006"),
+      Code::K8S007 => write!(f, "K8S007"),
+    }
+  }
 }

--- a/eksup/src/k8s/findings.rs
+++ b/eksup/src/k8s/findings.rs
@@ -2,18 +2,15 @@ use anyhow::Result;
 use kube::Client as K8sClient;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-  finding::Findings,
-  k8s::{
-    checks::{self, K8sFindings},
-    resources,
-  },
+use crate::k8s::{
+  checks::{self, K8sFindings},
+  resources,
 };
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct KubernetesFindings {
-  pub min_replicas: Option<String>,
-  pub min_ready_seconds: Option<String>,
+  pub min_replicas: Vec<checks::MinReplicas>,
+  pub min_ready_seconds: Vec<checks::MinReadySeconds>,
 }
 
 pub async fn get_kubernetes_findings(k8s_client: &K8sClient) -> Result<KubernetesFindings> {
@@ -24,7 +21,7 @@ pub async fn get_kubernetes_findings(k8s_client: &K8sClient) -> Result<Kubernete
     resources.iter().filter_map(|s| s.min_ready_seconds()).collect();
 
   Ok(KubernetesFindings {
-    min_replicas: min_replicas.to_markdown_table("\t"),
-    min_ready_seconds: min_ready_seconds.to_markdown_table("\t"),
+    min_replicas,
+    min_ready_seconds,
   })
 }

--- a/eksup/src/k8s/mod.rs
+++ b/eksup/src/k8s/mod.rs
@@ -2,6 +2,6 @@ mod checks;
 mod findings;
 mod resources;
 
-pub use checks::{version_skew, NodeFinding};
+pub use checks::{version_skew, VersionSkew};
 pub use findings::{get_kubernetes_findings, KubernetesFindings};
 pub use resources::get_eniconfigs;

--- a/eksup/src/k8s/mod.rs
+++ b/eksup/src/k8s/mod.rs
@@ -2,6 +2,6 @@ mod checks;
 mod findings;
 mod resources;
 
-pub use checks::version_skew;
+pub use checks::{version_skew, NodeFinding};
 pub use findings::{get_kubernetes_findings, KubernetesFindings};
 pub use resources::get_eniconfigs;

--- a/eksup/src/k8s/resources.rs
+++ b/eksup/src/k8s/resources.rs
@@ -5,6 +5,7 @@ use k8s_openapi::api::{apps, batch, core::v1::PodTemplateSpec};
 use kube::{api::Api, Client, CustomResource};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tabled::Tabled;
 
 use crate::{
   finding,
@@ -256,7 +257,8 @@ async fn get_cronjobs(client: &Client) -> Result<Vec<StdResource>> {
 //   Ok(nodes.items)
 // }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Tabled)]
+#[tabled(rename_all = "UpperCase")]
 pub struct Resource {
   /// Name of the resources
   pub name: String,
@@ -266,7 +268,7 @@ pub struct Resource {
   pub kind: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StdMetadata {
   pub name: String,
   pub namespace: String,
@@ -277,7 +279,7 @@ pub struct StdMetadata {
 
 /// This is a generalized spec used across all resource types that
 /// we are inspecting for finding violations
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StdSpec {
   /// Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
   pub min_ready_seconds: Option<i32>,
@@ -289,7 +291,7 @@ pub struct StdSpec {
   pub template: Option<PodTemplateSpec>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StdResource {
   pub metadata: StdMetadata,
   pub spec: StdSpec,

--- a/eksup/src/k8s/resources.rs
+++ b/eksup/src/k8s/resources.rs
@@ -312,11 +312,16 @@ impl K8sFindings for StdResource {
     match replicas {
       Some(replicas) => {
         if replicas < 3 {
+          let remediation = finding::Remediation::Required;
+          let finding = finding::Finding {
+            code: finding::Code::K8S002,
+            symbol: remediation.symbol(),
+            remediation,
+          };
           Some(MinReplicas {
+            finding,
             resource: self.get_resource(),
             replicas,
-            remediation: finding::Remediation::Required,
-            fcode: finding::Code::K8S002,
           })
         } else {
           None
@@ -332,11 +337,17 @@ impl K8sFindings for StdResource {
     match seconds {
       Some(seconds) => {
         if seconds < 1 {
+          let remediation = finding::Remediation::Required;
+          let finding = finding::Finding {
+            code: finding::Code::K8S003,
+            symbol: remediation.symbol(),
+            remediation,
+          };
+
           Some(MinReadySeconds {
+            finding,
             resource: self.get_resource(),
             seconds,
-            remediation: finding::Remediation::Required,
-            fcode: finding::Code::K8S003,
           })
         } else {
           None

--- a/eksup/src/output.rs
+++ b/eksup/src/output.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::analysis;
 
+/// Converts vec into comma separated string for tabled output
+pub fn tabled_vec_to_string(v: &[String]) -> String {
+  v.join(", ")
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum, Serialize, Deserialize)]
 pub enum Format {
   /// JSON format used for logging or writing to a *.json file
@@ -23,7 +28,7 @@ impl Default for Format {
 pub(crate) async fn output(results: &analysis::Results, format: &Format, filename: &Option<String>) -> Result<()> {
   let output = match format {
     Format::Json => serde_json::to_string(&results)?,
-    Format::Text => format!("{results:#?}"),
+    Format::Text => results.to_stdout_table()?,
   };
 
   match filename {

--- a/eksup/src/playbook.rs
+++ b/eksup/src/playbook.rs
@@ -125,8 +125,8 @@ pub(crate) fn create(args: &Playbook, cluster: &Cluster, analysis: analysis::Res
     region: region.to_owned(),
     cluster_name: cluster_name.to_owned(),
     target_version: target_version.to_owned(),
-    eks_managed_nodegroup_health: data_plane_findings.eks_managed_nodegroup_health.to_owned(),
-    eks_managed_nodegroup_update: data_plane_findings.eks_managed_nodegroup_update.to_owned(),
+    eks_managed_nodegroup_health: data_plane_findings.eks_managed_nodegroup_health.to_markdown_table("\t"),
+    eks_managed_nodegroup_update: data_plane_findings.eks_managed_nodegroup_update.to_markdown_table("\t"),
   };
   let eks_managed_nodegroup_template = char_replace(handlebars.render("eks-managed-nodegroup.md", &eks_mng_tmpl_data)?);
 
@@ -134,7 +134,9 @@ pub(crate) fn create(args: &Playbook, cluster: &Cluster, analysis: analysis::Res
     region: region.to_owned(),
     cluster_name: cluster_name.to_owned(),
     target_version: target_version.to_owned(),
-    self_managed_nodegroup_update: data_plane_findings.self_managed_nodegroup_update.to_owned(),
+    self_managed_nodegroup_update: data_plane_findings
+      .self_managed_nodegroup_update
+      .to_markdown_table("\t"),
   };
   let self_managed_nodegroup_template =
     char_replace(handlebars.render("self-managed-nodegroup.md", &self_mng_tmpl_data)?);

--- a/examples/test-mixed_v1.24_upgrade.md
+++ b/examples/test-mixed_v1.24_upgrade.md
@@ -14,14 +14,14 @@
 - [Upgrade the Control Plane](#upgrade-the-control-plane)
     - [Control Plane Pre-Upgrade](#control-plane-pre-upgrade)
     - [Control Plane Upgrade](#control-plane-upgrade)
+- [Upgrade EKS Addons](#upgrade-eks-addons)
+    - [Addon Pre-Upgrade](#addon-pre-upgrade)
+    - [Addon Upgrade](#addon-upgrade)
 - [Upgrade the Data Plane](#upgrade-the-data-plane)
     - [Data Plane Pre-Upgrade](#data-plane-pre-upgrade)
         - [EKS Managed Nodegroup](#eks-managed-nodegroup)
         - [Self-Managed Nodegroup](#self-managed-nodegroup)
         - [Fargate Profile](#fargate-profile)
-- [Upgrade EKS Addons](#upgrade-eks-addons)
-    - [Addon Pre-Upgrade](#addon-pre-upgrade)
-    - [Addon Upgrade](#addon-upgrade)
 - [Post-Upgrade](#post-upgrade)
 - [References](#references)
 
@@ -71,18 +71,17 @@
     </details>
 
     #### Check [[K8S001]](https://clowdhaus.github.io/eksup/process/checks/#k8s001)
-	|  -  | Nodes | Kubelet Version | Control Plane Version |
-	| :---: | :---: | :-------------- | :-------------------- |
-	| ⚠️ | 2 | `v1.22` | `v1.23` |
-	| ❌ | 2 | `v1.21` | `v1.23` |
+	| CHECK  |    | NODE  | CONTROL PLANE | SKEW | QUANTITY |
+	|--------|----|-------|---------------|------|----------|
+	| K8S001 | ⚠️  | v1.22 | v1.23         | +1   | 2        |
+	| K8S001 | ❌ | v1.21 | v1.23         | +2   | 2        |
 
-	|   -   | Node Name | Kubelet Version | Control Plane Version |
-	| :---: | :-------- | :-------------- | :-------------------- |
-	| ❌ | `ip-10-0-21-97.ec2.internal` | `v1.21` | `v1.23` |
-	| ❌ | `ip-10-0-31-138.ec2.internal` | `v1.21` | `v1.23` |
-	| ⚠️ | `ip-10-0-46-208.ec2.internal` | `v1.22` | `v1.23` |
-	| ⚠️ | `ip-10-0-6-50.ec2.internal` | `v1.22` | `v1.23` |
-
+	|    | NAME                        | NODE  | CONTROL PLANE | SKEW |
+	|----|-----------------------------|-------|---------------|------|
+	| ❌ | ip-10-0-0-205.ec2.internal  | v1.21 | v1.23         | +2   |
+	| ⚠️  | ip-10-0-18-21.ec2.internal  | v1.22 | v1.23         | +1   |
+	| ⚠️  | ip-10-0-22-218.ec2.internal | v1.22 | v1.23         | +1   |
+	| ❌ | ip-10-0-26-202.ec2.internal | v1.21 | v1.23         | +2   |
 
 
 3. Verify that there are at least 5 free IPs in the VPC subnets used by the control plane. Amazon EKS creates new elastic network interfaces (ENIs) in any of the subnets specified for the control plane. If there are not enough available IPs, then the upgrade will fail (your control plane will stay on the prior version).
@@ -141,11 +140,11 @@
     </details>
 
     #### Check [[EKS005]](https://clowdhaus.github.io/eksup/process/checks/#eks005)
-	|   -   | Name  | Version | Next Default | Next Latest |
-	| :---: | :---- | :-----: | :----------: | :---------: |
-	| ⚠️ | `coredns` | `v1.8.4-eksbuild.2` | `v1.8.7-eksbuild.3` | `v1.8.7-eksbuild.3` |
-	| ❌ | `kube-proxy` | `v1.21.14-eksbuild.3` | `v1.24.7-eksbuild.2` | `v1.24.9-eksbuild.1` |
-	| ❌ | `vpc-cni` | `v1.11.3-eksbuild.3` | `v1.11.4-eksbuild.1` | `v1.12.1-eksbuild.2` |
+	|    | NAME       | CURRENT             | LATEST             | DEFAULT            |
+	|----|------------|---------------------|--------------------|--------------------|
+	| ⚠️  | coredns    | v1.8.4-eksbuild.2   | v1.8.7-eksbuild.3  | v1.8.7-eksbuild.3  |
+	| ❌ | kube-proxy | v1.21.14-eksbuild.3 | v1.24.9-eksbuild.1 | v1.24.7-eksbuild.2 |
+	| ❌ | vpc-cni    | v1.11.3-eksbuild.3  | v1.12.2-eksbuild.1 | v1.11.4-eksbuild.1 |
 
 
 5. Check Kubernetes API versions currently in use and ensure any versions that are removed in the next Kubernetes release are updated prior to upgrading the cluster. There are several open source tools that can help you identify deprecated API versions in your Kubernetes manifests. The following open source projects support scanning both your cluster as well as manifest files to identify deprecated and/or removed API versions:
@@ -173,6 +172,36 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
         --query 'cluster.status'
     ```
 
+## Upgrade EKS Addons
+
+### Addon Pre-Upgrade
+
+1. Ensure the EKS addons in use are free of any health issues as reported by Amazon EKS. If there are any issues, resolution of those issues is required before upgrading the cluster.
+
+    <details>
+    <summary>📌 CLI Example</summary>
+
+    ```sh
+    aws eks describe-addon --region us-east-1 --cluster-name test-mixed \
+        --addon-name <ADDON_NAME> --query 'addon.health'
+    ```
+
+    </details>
+
+    #### Check [[EKS004]](https://clowdhaus.github.io/eksup/process/checks/#eks004)
+	✅ - There are no reported addon health issues.
+
+### Addon Upgrade
+
+1. Upgrade the addon to an appropriate version for the upgraded Kubernetes version:
+
+    ```sh
+    aws eks update-addon --region us-east-1 --cluster-name test-mixed \
+        --addon-name <ADDON_NAME> --addon-version <ADDON_VERSION>
+    ```
+
+    You may need to add `--resolve-conflicts OVERWRITE` to the command if the addon has been modified since it was deployed to ensure the addon is upgraded.
+
 ## Upgrade the Data Plane
 
 ### Data Plane Pre-Upgrade
@@ -182,12 +211,9 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
     🚧 TODO - fill in analysis results
 
     #### Check [[K8S002]](https://clowdhaus.github.io/eksup/process/checks/#k8s002)
-	|  -  | Name | Namespace | Kind | Minimum Replicas |
-	| :---: | :--- | :------ | :--- | :--------------- |
-	| ❌ | bad-dpl | deployment | Deployment | 1 |
-	| ❌ | coredns | kube-system | Deployment | 2 |
-	| ❌ | bad-ss | statefulset | StatefulSet | 1 |
-
+	|    | NAME    | NAMESPACE   | KIND       | REPLICAS |
+	|----|---------|-------------|------------|----------|
+	| ❌ | coredns | kube-system | Deployment | 2        |
 
 
     #### Check [[K8S003]](https://clowdhaus.github.io/eksup/process/checks/#k8s003)
@@ -257,9 +283,9 @@ The default update strategy for EKS managed nodegroups is a surge, rolling updat
     </details>
 
     Check [[EKS006]](https://clowdhaus.github.io/eksup/process/checks/#eks006)
-	|   -   | MNG Name  | Launch Template ID | Current | Latest |
-	| :---: | :-------- | :----------------- | :-----: | :----: |
-	| ⚠️ | `standard-2023012520034032750000002d` | `lt-06aa285a3b55fa0b6` | `1` | `2` |
+	|   | MANAGED NODEGROUP                   | LAUNCH TEMP ID       | CURRENT | LATEST |
+	|---|-------------------------------------|----------------------|---------|--------|
+	| ⚠️ | standard-2023021612275084860000002d | lt-05bf772fc86aeec1b | 1       | 2      |
 
 
 ##### Upgrade
@@ -333,9 +359,9 @@ A starting point for the instance refresh configuration is to use a value of 70%
     </details>
 
     Check [[EKS007]](https://clowdhaus.github.io/eksup/process/checks/#eks007)
-	|   -   | ASG Name | Launch Template ID | Current | Latest |
-	| :---: | :------- | :----------------- | :-----: | :----: |
-	| ⚠️ | `different-20230125200340605200000031` | `lt-00c9c5fd3111c1e01` | `1` | `2` |
+	|   | AUTOSCALING GROUP                    | LAUNCH TEMP ID       | CURRENT | LATEST |
+	|---|--------------------------------------|----------------------|---------|--------|
+	| ⚠️ | different-20230216122750926300000031 | lt-0d5a725fa6187e683 | 1       | 2      |
 
 
 ##### Upgrade
@@ -401,36 +427,6 @@ The Kubernetes version used by Fargate nodes is referenced from the control plan
     kubectl drain <FARGATE-NODE> --delete-emptydir-data
     ```
 
-
-## Upgrade EKS Addons
-
-### Addon Pre-Upgrade
-
-1. Ensure the EKS addons in use are free of any health issues as reported by Amazon EKS. If there are any issues, resolution of those issues is required before upgrading the cluster.
-
-    <details>
-    <summary>📌 CLI Example</summary>
-
-    ```sh
-    aws eks describe-addon --region us-east-1 --cluster-name test-mixed \
-        --addon-name <ADDON_NAME> --query 'addon.health'
-    ```
-
-    </details>
-
-    #### Check [[EKS004]](https://clowdhaus.github.io/eksup/process/checks/#eks004)
-	✅ - There are no reported addon health issues.
-
-### Addon Upgrade
-
-1. Upgrade the addon to an appropriate version for the upgraded Kubernetes version:
-
-    ```sh
-    aws eks update-addon --region us-east-1 --cluster-name test-mixed \
-        --addon-name <ADDON_NAME> --addon-version <ADDON_VERSION>
-    ```
-
-    You may need to add `--resolve-conflicts OVERWRITE` to the command if the addon has been modified since it was deployed to ensure the addon is upgraded.
 
 ## Post Upgrade
 

--- a/examples/test-mixed_v1.24_upgrade.md
+++ b/examples/test-mixed_v1.24_upgrade.md
@@ -73,8 +73,8 @@
     #### Check [[K8S001]](https://clowdhaus.github.io/eksup/process/checks/#k8s001)
 	| CHECK  |    | NODE  | CONTROL PLANE | SKEW | QUANTITY |
 	|--------|----|-------|---------------|------|----------|
-	| K8S001 | ⚠️  | v1.22 | v1.23         | +1   | 2        |
 	| K8S001 | ❌ | v1.21 | v1.23         | +2   | 2        |
+	| K8S001 | ⚠️  | v1.22 | v1.23         | +1   | 2        |
 
 	|    | NAME                        | NODE  | CONTROL PLANE | SKEW |
 	|----|-----------------------------|-------|---------------|------|
@@ -211,9 +211,11 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
     🚧 TODO - fill in analysis results
 
     #### Check [[K8S002]](https://clowdhaus.github.io/eksup/process/checks/#k8s002)
-	|    | NAME    | NAMESPACE   | KIND       | REPLICAS |
-	|----|---------|-------------|------------|----------|
-	| ❌ | coredns | kube-system | Deployment | 2        |
+	|    | NAME    | NAMESPACE   | KIND        | REPLICAS |
+	|----|---------|-------------|-------------|----------|
+	| ❌ | bad-dpl | deployment  | Deployment  | 1        |
+	| ❌ | coredns | kube-system | Deployment  | 2        |
+	| ❌ | bad-ss  | statefulset | StatefulSet | 1        |
 
 
     #### Check [[K8S003]](https://clowdhaus.github.io/eksup/process/checks/#k8s003)


### PR DESCRIPTION
## Description
- Format output sent to stdout; currently uses a tabular format
- Format output of playbook report to use same formatter as stdout, but for markdown
- Re-order stdout output to follow sub-groups (AWS -> EKS -> K8s) and sequential check number

## Motivation and Context
- Resolves #1 
- Provides consistency in terms of reporting across different formats

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
