### PR TITLE
feat: Add support for reporting on the use of readiness probes [K8S006]

### DIFF
--- a/docs/process/checks.md
+++ b/docs/process/checks.md
@@ -211,15 +211,9 @@ Either `.spec.affinity.podAntiAffinity` or `.spec.topologySpreadConstraints` is 
 
 #### K8S006
 
-!!! info "🚧 _Not yet implemented_"
-
 **❌ Remediation required**
 
 A `readinessProbe` must be set to ensure traffic is not sent to pods before they are ready following their re-deployment from a node replacement.
-
-**⚠️ Remediation recommended**
-
-If a `livenessProbe`  is provided, it should not be the same as `readinessProbe`, and a `startupProbe` should also accompany it.
 
 #### K8S007
 

--- a/eksup/src/analysis.rs
+++ b/eksup/src/analysis.rs
@@ -34,6 +34,7 @@ impl Results {
     output.push_str(&self.data_plane.version_skew.to_stdout_table()?);
     output.push_str(&self.kubernetes.min_replicas.to_stdout_table()?);
     output.push_str(&self.kubernetes.min_ready_seconds.to_stdout_table()?);
+    output.push_str(&self.kubernetes.readiness_probe.to_stdout_table()?);
 
     Ok(output)
   }

--- a/eksup/src/k8s/findings.rs
+++ b/eksup/src/k8s/findings.rs
@@ -11,6 +11,7 @@ use crate::k8s::{
 pub struct KubernetesFindings {
   pub min_replicas: Vec<checks::MinReplicas>,
   pub min_ready_seconds: Vec<checks::MinReadySeconds>,
+  pub readiness_probe: Vec<checks::Probe>,
 }
 
 pub async fn get_kubernetes_findings(k8s_client: &K8sClient) -> Result<KubernetesFindings> {
@@ -19,9 +20,11 @@ pub async fn get_kubernetes_findings(k8s_client: &K8sClient) -> Result<Kubernete
   let min_replicas: Vec<checks::MinReplicas> = resources.iter().filter_map(|s| s.min_replicas()).collect();
   let min_ready_seconds: Vec<checks::MinReadySeconds> =
     resources.iter().filter_map(|s| s.min_ready_seconds()).collect();
+  let readiness_probe: Vec<checks::Probe> = resources.iter().filter_map(|s| s.readiness_probe()).collect();
 
   Ok(KubernetesFindings {
     min_replicas,
     min_ready_seconds,
+    readiness_probe,
   })
 }

--- a/eksup/src/playbook.rs
+++ b/eksup/src/playbook.rs
@@ -57,6 +57,7 @@ pub struct TemplateData {
   // kubernetes_findings: k8s::KubernetesFindings,
   min_replicas: String,
   min_ready_seconds: String,
+  readiness_probe: String,
 }
 
 fn get_release_data() -> Result<HashMap<Version, Release>> {
@@ -177,6 +178,7 @@ pub(crate) fn create(args: &Playbook, cluster: &Cluster, analysis: analysis::Res
     // kubernetes_findings,
     min_replicas: kubernetes_findings.min_replicas.to_markdown_table("\t")?,
     min_ready_seconds: kubernetes_findings.min_ready_seconds.to_markdown_table("\t")?,
+    readiness_probe: kubernetes_findings.readiness_probe.to_markdown_table("\t")?,
   };
 
   let filename = match &args.filename {

--- a/eksup/templates/playbook.md
+++ b/eksup/templates/playbook.md
@@ -209,6 +209,9 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
     #### Check [[K8S003]](https://clowdhaus.github.io/eksup/process/checks/#k8s003)
 {{ min_ready_seconds }}
 
+    #### Check [[K8S006]](https://clowdhaus.github.io/eksup/process/checks/#k8s006)
+{{ readiness_probe }}
+
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
 
 {{#if pod_ips}}

--- a/examples/test-mixed_v1.24_upgrade.md
+++ b/examples/test-mixed_v1.24_upgrade.md
@@ -73,8 +73,8 @@
     #### Check [[K8S001]](https://clowdhaus.github.io/eksup/process/checks/#k8s001)
 	| CHECK  |    | NODE  | CONTROL PLANE | SKEW | QUANTITY |
 	|--------|----|-------|---------------|------|----------|
-	| K8S001 | ❌ | v1.21 | v1.23         | +2   | 2        |
 	| K8S001 | ⚠️  | v1.22 | v1.23         | +1   | 2        |
+	| K8S001 | ❌ | v1.21 | v1.23         | +2   | 2        |
 
 	|    | NAME                        | NODE  | CONTROL PLANE | SKEW |
 	|----|-----------------------------|-------|---------------|------|
@@ -142,7 +142,7 @@
     #### Check [[EKS005]](https://clowdhaus.github.io/eksup/process/checks/#eks005)
 	|    | NAME       | CURRENT             | LATEST             | DEFAULT            |
 	|----|------------|---------------------|--------------------|--------------------|
-	| ⚠️  | coredns    | v1.8.4-eksbuild.2   | v1.8.7-eksbuild.3  | v1.8.7-eksbuild.3  |
+	| ⚠️  | coredns    | v1.8.4-eksbuild.2   | v1.9.3-eksbuild.2  | v1.8.7-eksbuild.3  |
 	| ❌ | kube-proxy | v1.21.14-eksbuild.3 | v1.24.9-eksbuild.1 | v1.24.7-eksbuild.2 |
 	| ❌ | vpc-cni    | v1.11.3-eksbuild.3  | v1.12.2-eksbuild.1 | v1.11.4-eksbuild.1 |
 
@@ -220,6 +220,13 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
 
     #### Check [[K8S003]](https://clowdhaus.github.io/eksup/process/checks/#k8s003)
 	✅ - All relevant Kubernetes workloads minReadySeconds set to more than 0
+
+    #### Check [[K8S006]](https://clowdhaus.github.io/eksup/process/checks/#k8s006)
+	|    | NAME    | NAMESPACE   | KIND        |
+	|----|---------|-------------|-------------|
+	| ❌ | bad-dpl | deployment  | Deployment  |
+	| ❌ | bad-ss  | statefulset | StatefulSet |
+
 
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
 


### PR DESCRIPTION
## Description
- Add support for reporting on the use of readiness probes

## Motivation and Context
- Resolves #7 

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
