### PR TITLE
feat: Add support for check `K8S005` for pod topology distribution

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -29,5 +29,6 @@ This document captures the steps to follow when releasing a new version of `eksu
 5. Update package on crates.io. Update the version of `eksup` used throughout the project as well as within `Cargo.toml`. Commit the changes and push to `main` before publishing the new version to crates.io.
 
   ```sh
+  cd eksup
   cargo publish
   ```

--- a/docs/process/checks.md
+++ b/docs/process/checks.md
@@ -193,8 +193,6 @@ The Kubernetes eviction API is the preferred method for draining nodes for repla
 
 #### K8S005
 
-!!! info "🚧 _Not yet implemented_"
-
 **❌ Remediation required**
 
 Either `.spec.affinity.podAntiAffinity` or `.spec.topologySpreadConstraints` is set to avoid multiple pods from the same workload from being scheduled on the same node.
@@ -210,8 +208,6 @@ Either `.spec.affinity.podAntiAffinity` or `.spec.topologySpreadConstraints` is 
 [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
 
 #### K8S006
-
-**❌ Remediation required**
 
 A `readinessProbe` must be set to ensure traffic is not sent to pods before they are ready following their re-deployment from a node replacement.
 

--- a/eksup/src/analysis.rs
+++ b/eksup/src/analysis.rs
@@ -34,6 +34,7 @@ impl Results {
     output.push_str(&self.data_plane.version_skew.to_stdout_table()?);
     output.push_str(&self.kubernetes.min_replicas.to_stdout_table()?);
     output.push_str(&self.kubernetes.min_ready_seconds.to_stdout_table()?);
+    output.push_str(&self.kubernetes.pod_topology_distribution.to_stdout_table()?);
     output.push_str(&self.kubernetes.readiness_probe.to_stdout_table()?);
 
     Ok(output)

--- a/eksup/src/k8s/findings.rs
+++ b/eksup/src/k8s/findings.rs
@@ -12,6 +12,7 @@ pub struct KubernetesFindings {
   pub min_replicas: Vec<checks::MinReplicas>,
   pub min_ready_seconds: Vec<checks::MinReadySeconds>,
   pub readiness_probe: Vec<checks::Probe>,
+  pub pod_topology_distribution: Vec<checks::PodTopologyDistribution>,
 }
 
 pub async fn get_kubernetes_findings(k8s_client: &K8sClient) -> Result<KubernetesFindings> {
@@ -21,10 +22,13 @@ pub async fn get_kubernetes_findings(k8s_client: &K8sClient) -> Result<Kubernete
   let min_ready_seconds: Vec<checks::MinReadySeconds> =
     resources.iter().filter_map(|s| s.min_ready_seconds()).collect();
   let readiness_probe: Vec<checks::Probe> = resources.iter().filter_map(|s| s.readiness_probe()).collect();
+  let pod_topology_distribution: Vec<checks::PodTopologyDistribution> =
+    resources.iter().filter_map(|s| s.pod_topology_distribution()).collect();
 
   Ok(KubernetesFindings {
     min_replicas,
     min_ready_seconds,
     readiness_probe,
+    pod_topology_distribution,
   })
 }


### PR DESCRIPTION
## Description
- Add support for check `K8S005` for pod topology distribution

## Motivation and Context
- Check `K8S005` adds support for ensuring workload resources have either a `podAntiAffinity` set or a `topologySpreadConstraints` before upgrading to avoid/minimize any potential service disruption

Resolves #6

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
