### PR TITLE
feat: Add check `K8S007` for `TerminationGracePeriodSeconds` on StatefulSets

### DIFF
--- a/docs/process/checks.md
+++ b/docs/process/checks.md
@@ -213,8 +213,6 @@ A `readinessProbe` must be set to ensure traffic is not sent to pods before they
 
 #### K8S007
 
-!!! info "🚧 _Not yet implemented_"
-
 **❌ Remediation required**
 
 The `StatefulSet` should not specify a `TerminationGracePeriodSeconds` of 0

--- a/eksup/src/analysis.rs
+++ b/eksup/src/analysis.rs
@@ -36,6 +36,7 @@ impl Results {
     output.push_str(&self.kubernetes.min_ready_seconds.to_stdout_table()?);
     output.push_str(&self.kubernetes.pod_topology_distribution.to_stdout_table()?);
     output.push_str(&self.kubernetes.readiness_probe.to_stdout_table()?);
+    output.push_str(&self.kubernetes.termination_grace_period.to_stdout_table()?);
 
     Ok(output)
   }

--- a/eksup/src/k8s/checks.rs
+++ b/eksup/src/k8s/checks.rs
@@ -328,7 +328,7 @@ pub struct TerminationGracePeriod {
   #[tabled(inline)]
   pub resource: Resource,
   /// Min ready seconds
-  pub seconds: i32,
+  pub termination_grace_period: i64,
 }
 
 impl Findings for Vec<TerminationGracePeriod> {
@@ -416,6 +416,9 @@ pub trait K8sFindings {
 
   /// K8S006 - check if resources have readinessProbe
   fn readiness_probe(&self) -> Option<Probe>;
+
+  /// K8S007 - check if StatefulSets have terminationGracePeriodSeconds == 0
+  fn termination_grace_period(&self) -> Option<TerminationGracePeriod>;
 
   // /// K8S008 - check if resources use the Docker socket
   // fn docker_socket(&self) -> Option<DockerSocket>;

--- a/eksup/src/k8s/findings.rs
+++ b/eksup/src/k8s/findings.rs
@@ -13,6 +13,7 @@ pub struct KubernetesFindings {
   pub min_ready_seconds: Vec<checks::MinReadySeconds>,
   pub readiness_probe: Vec<checks::Probe>,
   pub pod_topology_distribution: Vec<checks::PodTopologyDistribution>,
+  pub termination_grace_period: Vec<checks::TerminationGracePeriod>,
 }
 
 pub async fn get_kubernetes_findings(k8s_client: &K8sClient) -> Result<KubernetesFindings> {
@@ -24,11 +25,14 @@ pub async fn get_kubernetes_findings(k8s_client: &K8sClient) -> Result<Kubernete
   let readiness_probe: Vec<checks::Probe> = resources.iter().filter_map(|s| s.readiness_probe()).collect();
   let pod_topology_distribution: Vec<checks::PodTopologyDistribution> =
     resources.iter().filter_map(|s| s.pod_topology_distribution()).collect();
+  let termination_grace_period: Vec<checks::TerminationGracePeriod> =
+    resources.iter().filter_map(|s| s.termination_grace_period()).collect();
 
   Ok(KubernetesFindings {
     min_replicas,
     min_ready_seconds,
     readiness_probe,
     pod_topology_distribution,
+    termination_grace_period,
   })
 }

--- a/eksup/src/k8s/resources.rs
+++ b/eksup/src/k8s/resources.rs
@@ -480,7 +480,7 @@ impl checks::K8sFindings for StdResource {
             if termination_grace_period <= 0 {
               let remediation = finding::Remediation::Required;
               let finding = finding::Finding {
-                code: finding::Code::K8S004,
+                code: finding::Code::K8S007,
                 symbol: remediation.symbol(),
                 remediation,
               };
@@ -491,6 +491,7 @@ impl checks::K8sFindings for StdResource {
                 termination_grace_period,
               })
             } else {
+              // Defaults to 30 seconds if not provided
               None
             }
           }

--- a/eksup/src/playbook.rs
+++ b/eksup/src/playbook.rs
@@ -57,8 +57,9 @@ pub struct TemplateData {
   // kubernetes_findings: k8s::KubernetesFindings,
   min_replicas: String,
   min_ready_seconds: String,
-  readiness_probe: String,
   pod_topology_distribution: String,
+  readiness_probe: String,
+  termination_grace_period: String,
 }
 
 fn get_release_data() -> Result<HashMap<Version, Release>> {
@@ -179,8 +180,9 @@ pub(crate) fn create(args: &Playbook, cluster: &Cluster, analysis: analysis::Res
     // kubernetes_findings,
     min_replicas: kubernetes_findings.min_replicas.to_markdown_table("\t")?,
     min_ready_seconds: kubernetes_findings.min_ready_seconds.to_markdown_table("\t")?,
-    readiness_probe: kubernetes_findings.readiness_probe.to_markdown_table("\t")?,
     pod_topology_distribution: kubernetes_findings.pod_topology_distribution.to_markdown_table("\t")?,
+    readiness_probe: kubernetes_findings.readiness_probe.to_markdown_table("\t")?,
+    termination_grace_period: kubernetes_findings.termination_grace_period.to_markdown_table("\t")?,
   };
 
   let filename = match &args.filename {

--- a/eksup/src/playbook.rs
+++ b/eksup/src/playbook.rs
@@ -58,6 +58,7 @@ pub struct TemplateData {
   min_replicas: String,
   min_ready_seconds: String,
   readiness_probe: String,
+  pod_topology_distribution: String,
 }
 
 fn get_release_data() -> Result<HashMap<Version, Release>> {
@@ -179,6 +180,7 @@ pub(crate) fn create(args: &Playbook, cluster: &Cluster, analysis: analysis::Res
     min_replicas: kubernetes_findings.min_replicas.to_markdown_table("\t")?,
     min_ready_seconds: kubernetes_findings.min_ready_seconds.to_markdown_table("\t")?,
     readiness_probe: kubernetes_findings.readiness_probe.to_markdown_table("\t")?,
+    pod_topology_distribution: kubernetes_findings.pod_topology_distribution.to_markdown_table("\t")?,
   };
 
   let filename = match &args.filename {

--- a/eksup/templates/playbook.md
+++ b/eksup/templates/playbook.md
@@ -212,6 +212,9 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
     #### Check [[K8S006]](https://clowdhaus.github.io/eksup/process/checks/#k8s006)
 {{ readiness_probe }}
 
+    #### Check [[K8S007]](https://clowdhaus.github.io/eksup/process/checks/#k8s007)
+{{ pod_topology_distribution }}
+
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
 
 {{#if pod_ips}}

--- a/eksup/templates/playbook.md
+++ b/eksup/templates/playbook.md
@@ -209,11 +209,17 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
     #### Check [[K8S003]](https://clowdhaus.github.io/eksup/process/checks/#k8s003)
 {{ min_ready_seconds }}
 
+    #### Check [[K8S004]](https://clowdhaus.github.io/eksup/process/checks/#k8s004)
+    🚧 TODO
+
+    #### Check [[K8S005]](https://clowdhaus.github.io/eksup/process/checks/#k8s005)
+{{ pod_topology_distribution }}
+
     #### Check [[K8S006]](https://clowdhaus.github.io/eksup/process/checks/#k8s006)
 {{ readiness_probe }}
 
     #### Check [[K8S007]](https://clowdhaus.github.io/eksup/process/checks/#k8s007)
-{{ pod_topology_distribution }}
+{{ termination_grace_period }}
 
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
 

--- a/examples/test-mixed_v1.24_upgrade.md
+++ b/examples/test-mixed_v1.24_upgrade.md
@@ -73,8 +73,8 @@
     #### Check [[K8S001]](https://clowdhaus.github.io/eksup/process/checks/#k8s001)
 	| CHECK  |    | NODE  | CONTROL PLANE | SKEW | QUANTITY |
 	|--------|----|-------|---------------|------|----------|
-	| K8S001 | ❌ | v1.21 | v1.23         | +2   | 2        |
 	| K8S001 | ⚠️  | v1.22 | v1.23         | +1   | 2        |
+	| K8S001 | ❌ | v1.21 | v1.23         | +2   | 2        |
 
 	|    | NAME                        | NODE  | CONTROL PLANE | SKEW |
 	|----|-----------------------------|-------|---------------|------|
@@ -225,6 +225,16 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
 	| ❌ | good-ss  | statefulset | StatefulSet | 0       |
 
 
+    #### Check [[K8S004]](https://clowdhaus.github.io/eksup/process/checks/#k8s004)
+    🚧 TODO
+
+    #### Check [[K8S005]](https://clowdhaus.github.io/eksup/process/checks/#k8s005)
+	|    | NAME    | NAMESPACE   | KIND        | ANTIAFFINITY | TOPOLOGYSPREADCONSTRAINTS |
+	|----|---------|-------------|-------------|--------------|---------------------------|
+	| ❌ | bad-dpl | deployment  | Deployment  | false        | false                     |
+	| ❌ | bad-ss  | statefulset | StatefulSet | false        | false                     |
+
+
     #### Check [[K8S006]](https://clowdhaus.github.io/eksup/process/checks/#k8s006)
 	|    | NAME    | NAMESPACE   | KIND        | READINESS PROBE |
 	|----|---------|-------------|-------------|-----------------|
@@ -233,10 +243,9 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
 
 
     #### Check [[K8S007]](https://clowdhaus.github.io/eksup/process/checks/#k8s007)
-	|    | NAME    | NAMESPACE   | KIND        | ANTIAFFINITY | TOPOLOGYSPREADCONSTRAINTS |
-	|----|---------|-------------|-------------|--------------|---------------------------|
-	| ❌ | bad-dpl | deployment  | Deployment  | false        | false                     |
-	| ❌ | bad-ss  | statefulset | StatefulSet | false        | false                     |
+	|    | NAME   | NAMESPACE   | KIND        | TERMINATIONGRACEPERIOD |
+	|----|--------|-------------|-------------|------------------------|
+	| ❌ | bad-ss | statefulset | StatefulSet | 0                      |
 
 
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.

--- a/examples/test-mixed_v1.24_upgrade.md
+++ b/examples/test-mixed_v1.24_upgrade.md
@@ -73,15 +73,15 @@
     #### Check [[K8S001]](https://clowdhaus.github.io/eksup/process/checks/#k8s001)
 	| CHECK  |    | NODE  | CONTROL PLANE | SKEW | QUANTITY |
 	|--------|----|-------|---------------|------|----------|
-	| K8S001 | ⚠️  | v1.22 | v1.23         | +1   | 2        |
 	| K8S001 | ❌ | v1.21 | v1.23         | +2   | 2        |
+	| K8S001 | ⚠️  | v1.22 | v1.23         | +1   | 2        |
 
 	|    | NAME                        | NODE  | CONTROL PLANE | SKEW |
 	|----|-----------------------------|-------|---------------|------|
-	| ❌ | ip-10-0-14-226.ec2.internal | v1.21 | v1.23         | +2   |
-	| ⚠️  | ip-10-0-29-79.ec2.internal  | v1.22 | v1.23         | +1   |
-	| ⚠️  | ip-10-0-35-98.ec2.internal  | v1.22 | v1.23         | +1   |
-	| ❌ | ip-10-0-46-207.ec2.internal | v1.21 | v1.23         | +2   |
+	| ⚠️  | ip-10-0-14-94.ec2.internal  | v1.22 | v1.23         | +1   |
+	| ⚠️  | ip-10-0-29-253.ec2.internal | v1.22 | v1.23         | +1   |
+	| ❌ | ip-10-0-39-157.ec2.internal | v1.21 | v1.23         | +2   |
+	| ❌ | ip-10-0-8-51.ec2.internal   | v1.21 | v1.23         | +2   |
 
 
 3. Verify that there are at least 5 free IPs in the VPC subnets used by the control plane. Amazon EKS creates new elastic network interfaces (ENIs) in any of the subnets specified for the control plane. If there are not enough available IPs, then the upgrade will fail (your control plane will stay on the prior version).
@@ -219,13 +219,24 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
 
 
     #### Check [[K8S003]](https://clowdhaus.github.io/eksup/process/checks/#k8s003)
-	✅ - All relevant Kubernetes workloads minReadySeconds set to more than 0
+	|    | NAME     | NAMESPACE   | KIND        | SECONDS |
+	|----|----------|-------------|-------------|---------|
+	| ⚠️  | good-dpl | deployment  | Deployment  | 0       |
+	| ❌ | good-ss  | statefulset | StatefulSet | 0       |
+
 
     #### Check [[K8S006]](https://clowdhaus.github.io/eksup/process/checks/#k8s006)
 	|    | NAME    | NAMESPACE   | KIND        | READINESS PROBE |
 	|----|---------|-------------|-------------|-----------------|
 	| ❌ | bad-dpl | deployment  | Deployment  | false           |
 	| ❌ | bad-ss  | statefulset | StatefulSet | false           |
+
+
+    #### Check [[K8S007]](https://clowdhaus.github.io/eksup/process/checks/#k8s007)
+	|    | NAME    | NAMESPACE   | KIND        | ANTIAFFINITY | TOPOLOGYSPREADCONSTRAINTS |
+	|----|---------|-------------|-------------|--------------|---------------------------|
+	| ❌ | bad-dpl | deployment  | Deployment  | false        | false                     |
+	| ❌ | bad-ss  | statefulset | StatefulSet | false        | false                     |
 
 
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
@@ -294,7 +305,7 @@ The default update strategy for EKS managed nodegroups is a surge, rolling updat
     Check [[EKS006]](https://clowdhaus.github.io/eksup/process/checks/#eks006)
 	|   | MANAGED NODEGROUP                   | LAUNCH TEMP ID       | CURRENT | LATEST |
 	|---|-------------------------------------|----------------------|---------|--------|
-	| ⚠️ | standard-20230220143405204800000031 | lt-0e14f0c3876139d91 | 1       | 2      |
+	| ⚠️ | standard-2023022314320292470000002f | lt-0fd64ef2eed7c35e5 | 1       | 2      |
 
 
 ##### Upgrade
@@ -370,7 +381,7 @@ A starting point for the instance refresh configuration is to use a value of 70%
     Check [[EKS007]](https://clowdhaus.github.io/eksup/process/checks/#eks007)
 	|   | AUTOSCALING GROUP                    | LAUNCH TEMP ID       | CURRENT | LATEST |
 	|---|--------------------------------------|----------------------|---------|--------|
-	| ⚠️ | different-2023022014340517500000002d | lt-0f6ba2db540cc28cb | 1       | 2      |
+	| ⚠️ | different-20230223143203060000000031 | lt-0a85079cbff79cd84 | 1       | 2      |
 
 
 ##### Upgrade

--- a/examples/test-mixed_v1.24_upgrade.md
+++ b/examples/test-mixed_v1.24_upgrade.md
@@ -78,10 +78,10 @@
 
 	|    | NAME                        | NODE  | CONTROL PLANE | SKEW |
 	|----|-----------------------------|-------|---------------|------|
-	| ❌ | ip-10-0-0-205.ec2.internal  | v1.21 | v1.23         | +2   |
-	| ⚠️  | ip-10-0-18-21.ec2.internal  | v1.22 | v1.23         | +1   |
-	| ⚠️  | ip-10-0-22-218.ec2.internal | v1.22 | v1.23         | +1   |
-	| ❌ | ip-10-0-26-202.ec2.internal | v1.21 | v1.23         | +2   |
+	| ❌ | ip-10-0-14-226.ec2.internal | v1.21 | v1.23         | +2   |
+	| ⚠️  | ip-10-0-29-79.ec2.internal  | v1.22 | v1.23         | +1   |
+	| ⚠️  | ip-10-0-35-98.ec2.internal  | v1.22 | v1.23         | +1   |
+	| ❌ | ip-10-0-46-207.ec2.internal | v1.21 | v1.23         | +2   |
 
 
 3. Verify that there are at least 5 free IPs in the VPC subnets used by the control plane. Amazon EKS creates new elastic network interfaces (ENIs) in any of the subnets specified for the control plane. If there are not enough available IPs, then the upgrade will fail (your control plane will stay on the prior version).
@@ -222,10 +222,10 @@ When upgrading the control plane, Amazon EKS performs standard infrastructure an
 	✅ - All relevant Kubernetes workloads minReadySeconds set to more than 0
 
     #### Check [[K8S006]](https://clowdhaus.github.io/eksup/process/checks/#k8s006)
-	|    | NAME    | NAMESPACE   | KIND        |
-	|----|---------|-------------|-------------|
-	| ❌ | bad-dpl | deployment  | Deployment  |
-	| ❌ | bad-ss  | statefulset | StatefulSet |
+	|    | NAME    | NAMESPACE   | KIND        | READINESS PROBE |
+	|----|---------|-------------|-------------|-----------------|
+	| ❌ | bad-dpl | deployment  | Deployment  | false           |
+	| ❌ | bad-ss  | statefulset | StatefulSet | false           |
 
 
 2. Inspect [AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) before upgrading. Accounts that are multi-tenant or already have a number of resources provisioned may be at risk of hitting service quota limits which will cause the cluster upgrade to fail, or impede the upgrade process.
@@ -294,7 +294,7 @@ The default update strategy for EKS managed nodegroups is a surge, rolling updat
     Check [[EKS006]](https://clowdhaus.github.io/eksup/process/checks/#eks006)
 	|   | MANAGED NODEGROUP                   | LAUNCH TEMP ID       | CURRENT | LATEST |
 	|---|-------------------------------------|----------------------|---------|--------|
-	| ⚠️ | standard-2023021612275084860000002d | lt-05bf772fc86aeec1b | 1       | 2      |
+	| ⚠️ | standard-20230220143405204800000031 | lt-0e14f0c3876139d91 | 1       | 2      |
 
 
 ##### Upgrade
@@ -370,7 +370,7 @@ A starting point for the instance refresh configuration is to use a value of 70%
     Check [[EKS007]](https://clowdhaus.github.io/eksup/process/checks/#eks007)
 	|   | AUTOSCALING GROUP                    | LAUNCH TEMP ID       | CURRENT | LATEST |
 	|---|--------------------------------------|----------------------|---------|--------|
-	| ⚠️ | different-20230216122750926300000031 | lt-0d5a725fa6187e683 | 1       | 2      |
+	| ⚠️ | different-2023022014340517500000002d | lt-0f6ba2db540cc28cb | 1       | 2      |
 
 
 ##### Upgrade

--- a/tests/deployment.yaml
+++ b/tests/deployment.yaml
@@ -54,6 +54,13 @@ spec:
       labels:
         app: good-dpl
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+          topologyKey: topology.kubernetes.io/zone
+          labelSelector:
+            matchLabels:
+              app: good-dpl
       containers:
         - name: goproxy
           image: registry.k8s.io/goproxy:0.1

--- a/tests/replicaset.yaml
+++ b/tests/replicaset.yaml
@@ -54,6 +54,13 @@ spec:
       labels:
         app: rs
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+          topologyKey: topology.kubernetes.io/zone
+          labelSelector:
+            matchLabels:
+              app: good-rs
       containers:
         - name: goproxy
           image: registry.k8s.io/goproxy:0.1

--- a/tests/statefulset.yaml
+++ b/tests/statefulset.yaml
@@ -39,6 +39,8 @@ spec:
       labels:
         app: bad-ss
     spec:
+      # Defaults to 30s
+      terminationGracePeriodSeconds: 0
       containers:
         - name: goproxy
           image: registry.k8s.io/goproxy:0.1

--- a/tests/statefulset.yaml
+++ b/tests/statefulset.yaml
@@ -29,6 +29,7 @@ metadata:
     app: bad-ss
 spec:
   replicas: 1
+  minReadySeconds: 0
   serviceName: bad-ss
   selector:
     matchLabels:


### PR DESCRIPTION
## Description
- Add check `K8S007` for `TerminationGracePeriodSeconds` on StatefulSets
- Correct logic for `min_ready_seconds` due to default case (0)
- Fix reporting to ensure `K8s005` (`pod_topology_distribution`) is shown in report output

## Motivation and Context
- Adds new functionality for checking `TerminationGracePeriodSeconds` on StatefulSets
- Ensure results are reportedly correctly

Resolves #8

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.