### PR TITLE
fix: Update logic used to evaluate control plane IPs to ensure at least 2 AZs each have 5 or more IPs available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
  "aws-types",
  "clap",
  "handlebars",
+ "itertools",
  "k8s-openapi",
  "kube",
  "rust-embed",
@@ -1165,6 +1166,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/docs/process/checks.md
+++ b/docs/process/checks.md
@@ -54,7 +54,7 @@ Checks that are specific to Amazon EKS
 
 **❌ Remediation required**
 
-There are at least 5 available IPs for the control plane to upgrade; required for cross account ENI creation.
+There are at least 2 subnets in different availability zones, each with at least 5 available IPs for the control plane to upgrade.
 
 #### EKS002
 

--- a/eksup/Cargo.toml
+++ b/eksup/Cargo.toml
@@ -33,6 +33,7 @@ aws-sdk-eks = "0.24"
 aws-types = "0.54"
 clap = { version = "4.0", features = ["derive", "string"] }
 handlebars = { version = "4.3", features = ["rust-embed"] }
+itertools = "0.10"
 # https://kube.rs/kubernetes-version/
 k8s-openapi = { version = "0.17.0", default-features = false, features = ["v1_22"] }
 kube = { version = "0.80.0", default-features = false, features = [ "client", "derive", "rustls-tls" ] }

--- a/eksup/src/eks/findings.rs
+++ b/eksup/src/eks/findings.rs
@@ -28,10 +28,10 @@ pub async fn get_cluster_findings(cluster: &Cluster) -> Result<ClusterFindings> 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SubnetFindings {
   /// The Amazon EKS service requires at least 5 available IPs in order to upgrade a cluster in-place
-  pub control_plane_ips: Option<checks::InsufficientSubnetIps>,
+  pub control_plane_ips: Vec<checks::InsufficientSubnetIps>,
   /// This is the number of IPs available to pods when custom networking is enabled on the AWS VPC CNI,
   /// pulling the available number of IPs for the subnets listed in the ENIConfig resource(s)
-  pub pod_ips: Option<checks::InsufficientSubnetIps>,
+  pub pod_ips: Vec<checks::InsufficientSubnetIps>,
 }
 
 /// Collects findings related to networking and subnets

--- a/eksup/src/lib.rs
+++ b/eksup/src/lib.rs
@@ -131,8 +131,8 @@ pub async fn create(args: &Create) -> Result<()> {
 
       let results = analysis::analyze(&aws_config, &cluster).await?;
 
-      if let Err(_err) = playbook::create(playbook, region, &cluster, results) {
-        // eprintln!("{err}");
+      if let Err(err) = playbook::create(playbook, region, &cluster, results) {
+        eprintln!("{err}");
         process::exit(2);
       }
     }

--- a/examples/test-mixed_v1.24_upgrade.md
+++ b/examples/test-mixed_v1.24_upgrade.md
@@ -76,12 +76,12 @@
 	| K8S001 | ❌ | v1.21 | v1.23         | +2   | 2        |
 	| K8S001 | ❌ | v1.22 | v1.23         | +1   | 2        |
 
-	|    | NAME                       | NODE  | CONTROL PLANE | SKEW |
-	|----|----------------------------|-------|---------------|------|
-	| ❌ | ip-10-0-10-49.ec2.internal | v1.21 | v1.23         | +2   |
-	| ❌ | ip-10-0-14-22.ec2.internal | v1.22 | v1.23         | +1   |
-	| ❌ | ip-10-0-20-62.ec2.internal | v1.22 | v1.23         | +1   |
-	| ❌ | ip-10-0-7-12.ec2.internal  | v1.21 | v1.23         | +2   |
+	|    | NAME                        | NODE  | CONTROL PLANE | SKEW |
+	|----|-----------------------------|-------|---------------|------|
+	| ❌ | ip-10-0-0-100.ec2.internal  | v1.21 | v1.23         | +2   |
+	| ❌ | ip-10-0-14-188.ec2.internal | v1.22 | v1.23         | +1   |
+	| ❌ | ip-10-0-19-35.ec2.internal  | v1.21 | v1.23         | +2   |
+	| ❌ | ip-10-0-40-93.ec2.internal  | v1.22 | v1.23         | +1   |
 
 
 3. Verify that there are at least 5 free IPs in the VPC subnets used by the control plane. Amazon EKS creates new elastic network interfaces (ENIs) in any of the subnets specified for the control plane. If there are not enough available IPs, then the upgrade will fail (your control plane will stay on the prior version).
@@ -337,7 +337,7 @@ The default update strategy for EKS managed nodegroups is a surge, rolling updat
     Check [[EKS006]](https://clowdhaus.github.io/eksup/process/checks/#eks006)
 	|   | MANAGED NODEGROUP                   | LAUNCH TEMP ID       | CURRENT | LATEST |
 	|---|-------------------------------------|----------------------|---------|--------|
-	| ⚠️ | standard-20230310135434793800000027 | lt-0d8873f5c893efaa0 | 1       | 2      |
+	| ⚠️ | standard-20230311143408696200000027 | lt-0a9ebcea03f330711 | 1       | 2      |
 
 
 ##### Upgrade
@@ -413,7 +413,7 @@ A starting point for the instance refresh configuration is to use a value of 70%
     Check [[EKS007]](https://clowdhaus.github.io/eksup/process/checks/#eks007)
 	|   | AUTOSCALING GROUP                    | LAUNCH TEMP ID       | CURRENT | LATEST |
 	|---|--------------------------------------|----------------------|---------|--------|
-	| ⚠️ | different-20230310135435081600000029 | lt-0a880c2680a8cf174 | 1       | 2      |
+	| ⚠️ | different-20230311143408778000000029 | lt-061e6a6f3cc5c1db9 | 1       | 2      |
 
 
 ##### Upgrade


### PR DESCRIPTION
## Description
- Update logic used to evaluate control plane IPs to ensure at least 2 AZs each have 5 or more IPs available

## Motivation and Context

Resolves #24

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
