### PR TITLE
fix(k8s): ensure PodSecurityPolicies are not checked for version >= 1.25

### DIFF
--- a/eksup/src/k8s/resources.rs
+++ b/eksup/src/k8s/resources.rs
@@ -366,7 +366,7 @@ pub(crate) async fn get_podsecuritypolicies(
   current_version: &str,
 ) -> Result<Vec<checks::PodSecurityPolicy>> {
   let current_version = version::parse_minor(current_version)?;
-  if current_version <= 25 {
+  if current_version >= 25 {
     // Pod Security Policy support is removed starting in 1.25
     return Ok(vec![]);
   }


### PR DESCRIPTION
## Description

Fixes a bug where PodSecurityPolicies were being queried for Kubernetes version greater than or equal to 1.25.

## Motivation and Context

Resolves #47

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
