### PR TITLE
Don't fire K8S002 on zero-replica workloads

### DIFF
--- a/eksup/src/k8s/resources.rs
+++ b/eksup/src/k8s/resources.rs
@@ -462,7 +462,7 @@ impl checks::K8sFindings for StdResource {
 
     match replicas {
       Some(replicas) => {
-        if replicas < 3 {
+        if replicas < 3 && replicas > 0 {
           let remediation = finding::Remediation::Required;
           let finding = finding::Finding {
             code: finding::Code::K8S002,

--- a/tests/deployment.yaml
+++ b/tests/deployment.yaml
@@ -83,3 +83,51 @@ spec:
         - name: tmp
           hostPath:
             path: /tmp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ignored-dpl
+  namespace: deployment
+  labels:
+    app: ignored-dpl
+spec:
+  replicas: 0
+  minReadySeconds: 0
+  selector:
+    matchLabels:
+      app: ignored-dpl
+  template:
+    metadata:
+      labels:
+        app: ignored-dpl
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+          topologyKey: topology.kubernetes.io/zone
+          labelSelector:
+            matchLabels:
+              app: ignored-dpl
+      containers:
+        - name: goproxy
+          image: registry.k8s.io/goproxy:0.1
+          ports:
+          - containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          hostPath:
+            path: /tmp


### PR DESCRIPTION
By definition, a workload with no pods can't be disrupted by an upgrade.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of ~~your choice~~ the Apache-2.0 license.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
