### PR TITLE
feat: Add support for EKS 1.30

### DIFF
--- a/eksup/src/version.rs
+++ b/eksup/src/version.rs
@@ -6,7 +6,7 @@ use seq_macro::seq;
 use serde::{Deserialize, Serialize};
 
 /// Latest support version
-pub const LATEST: &str = "1.29";
+pub const LATEST: &str = "1.30";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Versions {


### PR DESCRIPTION
## Description
Add support for EKS 1.30

## Motivation and Context
EKS 1.30 was released on May 23, 2024. [[source](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)]

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
