### PR TITLE
feat: shell completions and man page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+completions/* linguist-generated=true
+man/eksup.1   linguist-generated=true

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,53 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: nightly
+          components: rustfmt
+      - run: cargo +nightly fmt --all --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          components: clippy
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo test --all
+
+  verify-generated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: xtask
+      - run: cargo xtask generate-all --check

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,9 +6,6 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yaml'
-      - 'xtask/**'
-      - 'eksup/src/finding.rs'
-      - 'eksup/src/version.rs'
 
 permissions:
   contents: write
@@ -18,23 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
-
       - run: pip install mkdocs-material pymdown-extensions
-
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: xtask
-
-      - name: Verify docs are up to date
-        run: cargo xtask generate-docs --check
-
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,6 +111,7 @@ jobs:
         mkdir -p "${STAGING}"
 
         cp {README.md,LICENSE} "${STAGING}/"
+        cp -r completions man "${STAGING}/"
 
         if [ "${{ matrix.os }}" = "windows-2025" ]; then
           cp "target/${{ matrix.target }}/release/eksup.exe" "${STAGING}/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +736,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "cmake"
@@ -1037,6 +1056,8 @@ dependencies = [
  "aws-sdk-servicequotas",
  "clap",
  "clap-verbosity-flag",
+ "clap_complete",
+ "clap_mangen",
  "handlebars",
  "indicatif",
  "insta",
@@ -2314,6 +2335,12 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rust-embed"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,6 +3502,10 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
+ "clap_complete",
+ "clap_mangen",
+ "eksup",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ cargo build --release
 0.13.0
 ```
 
+### Shell completions
+
+`eksup` supports shell completion for bash, zsh, fish, powershell, and elvish.
+See the [shell completions guide](https://clowdhaus.github.io/eksup/install/shell-completions/)
+for install instructions, or run:
+
+```sh
+eksup completion <shell> > <completion-script-path>
+```
+
+A man page is also generated:
+
+```sh
+eksup man > /usr/local/share/man/man1/eksup.1
+```
+
 ## Local Development
 
 `eksup` uses Rust stable for production builds, but nightly for local development for formatting and linting. It is not a requirement to use nightly, but if running `fmt` you may see a few warnings on certain features only being available on nightly.

--- a/completions/_eksup
+++ b/completions/_eksup
@@ -1,0 +1,322 @@
+#compdef eksup
+
+autoload -U is-at-least
+
+_eksup() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" : \
+'*-v[Increase logging verbosity]' \
+'*--verbose[Increase logging verbosity]' \
+'(-v --verbose)*-q[Decrease logging verbosity]' \
+'(-v --verbose)*--quiet[Decrease logging verbosity]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_eksup_commands" \
+"*::: :->eksup" \
+&& ret=0
+    case $state in
+    (eksup)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:eksup-command-$line[1]:"
+        case $line[1] in
+            (analyze)
+_arguments "${_arguments_options[@]}" : \
+'-c+[The name of the cluster to analyze]:CLUSTER:_default' \
+'--cluster=[The name of the cluster to analyze]:CLUSTER:_default' \
+'-r+[The AWS region where the cluster is provisioned]:REGION:_default' \
+'--region=[The AWS region where the cluster is provisioned]:REGION:_default' \
+'-p+[The AWS profile to use to access the cluster]:PROFILE:_default' \
+'--profile=[The AWS profile to use to access the cluster]:PROFILE:_default' \
+'-f+[]:FORMAT:((json\:"JSON format used for logging or writing to a *.json file"
+text\:"Text format used for writing to stdout"))' \
+'--format=[]:FORMAT:((json\:"JSON format used for logging or writing to a *.json file"
+text\:"Text format used for writing to stdout"))' \
+'-o+[Write to file instead of stdout]:OUTPUT:_default' \
+'--output=[Write to file instead of stdout]:OUTPUT:_default' \
+'-t+[Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1]:TARGET_VERSION:_default' \
+'--target-version=[Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1]:TARGET_VERSION:_default' \
+'--config=[Path to an eksup configuration file (default\: .eksup.yaml in cwd)]:CONFIG:_default' \
+'--ignore-recommended[Exclude recommendations from the output]' \
+'*-v[Increase logging verbosity]' \
+'*--verbose[Increase logging verbosity]' \
+'(-v --verbose)*-q[Decrease logging verbosity]' \
+'(-v --verbose)*--quiet[Decrease logging verbosity]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'*-v[Increase logging verbosity]' \
+'*--verbose[Increase logging verbosity]' \
+'(-v --verbose)*-q[Decrease logging verbosity]' \
+'(-v --verbose)*--quiet[Decrease logging verbosity]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_eksup__subcmd__create_commands" \
+"*::: :->create" \
+&& ret=0
+
+    case $state in
+    (create)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:eksup-create-command-$line[1]:"
+        case $line[1] in
+            (playbook)
+_arguments "${_arguments_options[@]}" : \
+'-c+[The name of the cluster to analyze]:CLUSTER:_default' \
+'--cluster=[The name of the cluster to analyze]:CLUSTER:_default' \
+'-r+[The AWS region where the cluster is provisioned]:REGION:_default' \
+'--region=[The AWS region where the cluster is provisioned]:REGION:_default' \
+'-p+[The AWS profile to use to access the cluster]:PROFILE:_default' \
+'--profile=[The AWS profile to use to access the cluster]:PROFILE:_default' \
+'-f+[Name of the playbook saved locally]:FILENAME:_default' \
+'--filename=[Name of the playbook saved locally]:FILENAME:_default' \
+'-t+[Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1]:TARGET_VERSION:_default' \
+'--target-version=[Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1]:TARGET_VERSION:_default' \
+'--config=[Path to an eksup configuration file (default\: .eksup.yaml in cwd)]:CONFIG:_default' \
+'--ignore-recommended[Exclude recommendations from the output]' \
+'*-v[Increase logging verbosity]' \
+'*--verbose[Increase logging verbosity]' \
+'(-v --verbose)*-q[Decrease logging verbosity]' \
+'(-v --verbose)*--quiet[Decrease logging verbosity]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_eksup__subcmd__create__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:eksup-create-help-command-$line[1]:"
+        case $line[1] in
+            (playbook)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(completion)
+_arguments "${_arguments_options[@]}" : \
+'*-v[Increase logging verbosity]' \
+'*--verbose[Increase logging verbosity]' \
+'(-v --verbose)*-q[Decrease logging verbosity]' \
+'(-v --verbose)*--quiet[Decrease logging verbosity]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':shell -- The shell to generate completions for:(bash elvish fish powershell zsh)' \
+&& ret=0
+;;
+(man)
+_arguments "${_arguments_options[@]}" : \
+'*-v[Increase logging verbosity]' \
+'*--verbose[Increase logging verbosity]' \
+'(-v --verbose)*-q[Decrease logging verbosity]' \
+'(-v --verbose)*--quiet[Decrease logging verbosity]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_eksup__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:eksup-help-command-$line[1]:"
+        case $line[1] in
+            (analyze)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+":: :_eksup__subcmd__help__subcmd__create_commands" \
+"*::: :->create" \
+&& ret=0
+
+    case $state in
+    (create)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:eksup-help-create-command-$line[1]:"
+        case $line[1] in
+            (playbook)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(completion)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(man)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_eksup_commands] )) ||
+_eksup_commands() {
+    local commands; commands=(
+'analyze:Analyze an Amazon EKS cluster for potential upgrade issues' \
+'create:Create artifacts using the analysis data' \
+'completion:Generate shell completion script for the given shell' \
+'man:Generate the man page for eksup' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'eksup commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__analyze_commands] )) ||
+_eksup__subcmd__analyze_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup analyze commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__completion_commands] )) ||
+_eksup__subcmd__completion_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup completion commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__create_commands] )) ||
+_eksup__subcmd__create_commands() {
+    local commands; commands=(
+'playbook:Create a playbook for upgrading an Amazon EKS cluster' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'eksup create commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__create__subcmd__help_commands] )) ||
+_eksup__subcmd__create__subcmd__help_commands() {
+    local commands; commands=(
+'playbook:Create a playbook for upgrading an Amazon EKS cluster' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'eksup create help commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__create__subcmd__help__subcmd__help_commands] )) ||
+_eksup__subcmd__create__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup create help help commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__create__subcmd__help__subcmd__playbook_commands] )) ||
+_eksup__subcmd__create__subcmd__help__subcmd__playbook_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup create help playbook commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__create__subcmd__playbook_commands] )) ||
+_eksup__subcmd__create__subcmd__playbook_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup create playbook commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__help_commands] )) ||
+_eksup__subcmd__help_commands() {
+    local commands; commands=(
+'analyze:Analyze an Amazon EKS cluster for potential upgrade issues' \
+'create:Create artifacts using the analysis data' \
+'completion:Generate shell completion script for the given shell' \
+'man:Generate the man page for eksup' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'eksup help commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__help__subcmd__analyze_commands] )) ||
+_eksup__subcmd__help__subcmd__analyze_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup help analyze commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__help__subcmd__completion_commands] )) ||
+_eksup__subcmd__help__subcmd__completion_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup help completion commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__help__subcmd__create_commands] )) ||
+_eksup__subcmd__help__subcmd__create_commands() {
+    local commands; commands=(
+'playbook:Create a playbook for upgrading an Amazon EKS cluster' \
+    )
+    _describe -t commands 'eksup help create commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__help__subcmd__create__subcmd__playbook_commands] )) ||
+_eksup__subcmd__help__subcmd__create__subcmd__playbook_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup help create playbook commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__help__subcmd__help_commands] )) ||
+_eksup__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup help help commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__help__subcmd__man_commands] )) ||
+_eksup__subcmd__help__subcmd__man_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup help man commands' commands "$@"
+}
+(( $+functions[_eksup__subcmd__man_commands] )) ||
+_eksup__subcmd__man_commands() {
+    local commands; commands=()
+    _describe -t commands 'eksup man commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_eksup" ]; then
+    _eksup "$@"
+else
+    compdef _eksup eksup
+fi

--- a/completions/_eksup.ps1
+++ b/completions/_eksup.ps1
@@ -1,0 +1,164 @@
+
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+Register-ArgumentCompleter -Native -CommandName 'eksup' -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commandElements = $commandAst.CommandElements
+    $command = @(
+        'eksup'
+        for ($i = 1; $i -lt $commandElements.Count; $i++) {
+            $element = $commandElements[$i]
+            if ($element -isnot [StringConstantExpressionAst] -or
+                $element.StringConstantType -ne [StringConstantType]::BareWord -or
+                $element.Value.StartsWith('-') -or
+                $element.Value -eq $wordToComplete) {
+                break
+        }
+        $element.Value
+    }) -join ';'
+
+    $completions = @(switch ($command) {
+        'eksup' {
+            [CompletionResult]::new('-v', '-v', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('--verbose', '--verbose', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('-q', '-q', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('analyze', 'analyze', [CompletionResultType]::ParameterValue, 'Analyze an Amazon EKS cluster for potential upgrade issues')
+            [CompletionResult]::new('create', 'create', [CompletionResultType]::ParameterValue, 'Create artifacts using the analysis data')
+            [CompletionResult]::new('completion', 'completion', [CompletionResultType]::ParameterValue, 'Generate shell completion script for the given shell')
+            [CompletionResult]::new('man', 'man', [CompletionResultType]::ParameterValue, 'Generate the man page for eksup')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
+            break
+        }
+        'eksup;analyze' {
+            [CompletionResult]::new('-c', '-c', [CompletionResultType]::ParameterName, 'The name of the cluster to analyze')
+            [CompletionResult]::new('--cluster', '--cluster', [CompletionResultType]::ParameterName, 'The name of the cluster to analyze')
+            [CompletionResult]::new('-r', '-r', [CompletionResultType]::ParameterName, 'The AWS region where the cluster is provisioned')
+            [CompletionResult]::new('--region', '--region', [CompletionResultType]::ParameterName, 'The AWS region where the cluster is provisioned')
+            [CompletionResult]::new('-p', '-p', [CompletionResultType]::ParameterName, 'The AWS profile to use to access the cluster')
+            [CompletionResult]::new('--profile', '--profile', [CompletionResultType]::ParameterName, 'The AWS profile to use to access the cluster')
+            [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, 'f')
+            [CompletionResult]::new('--format', '--format', [CompletionResultType]::ParameterName, 'format')
+            [CompletionResult]::new('-o', '-o', [CompletionResultType]::ParameterName, 'Write to file instead of stdout')
+            [CompletionResult]::new('--output', '--output', [CompletionResultType]::ParameterName, 'Write to file instead of stdout')
+            [CompletionResult]::new('-t', '-t', [CompletionResultType]::ParameterName, 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1')
+            [CompletionResult]::new('--target-version', '--target-version', [CompletionResultType]::ParameterName, 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1')
+            [CompletionResult]::new('--config', '--config', [CompletionResultType]::ParameterName, 'Path to an eksup configuration file (default: .eksup.yaml in cwd)')
+            [CompletionResult]::new('--ignore-recommended', '--ignore-recommended', [CompletionResultType]::ParameterName, 'Exclude recommendations from the output')
+            [CompletionResult]::new('-v', '-v', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('--verbose', '--verbose', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('-q', '-q', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
+            break
+        }
+        'eksup;create' {
+            [CompletionResult]::new('-v', '-v', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('--verbose', '--verbose', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('-q', '-q', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('playbook', 'playbook', [CompletionResultType]::ParameterValue, 'Create a playbook for upgrading an Amazon EKS cluster')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
+            break
+        }
+        'eksup;create;playbook' {
+            [CompletionResult]::new('-c', '-c', [CompletionResultType]::ParameterName, 'The name of the cluster to analyze')
+            [CompletionResult]::new('--cluster', '--cluster', [CompletionResultType]::ParameterName, 'The name of the cluster to analyze')
+            [CompletionResult]::new('-r', '-r', [CompletionResultType]::ParameterName, 'The AWS region where the cluster is provisioned')
+            [CompletionResult]::new('--region', '--region', [CompletionResultType]::ParameterName, 'The AWS region where the cluster is provisioned')
+            [CompletionResult]::new('-p', '-p', [CompletionResultType]::ParameterName, 'The AWS profile to use to access the cluster')
+            [CompletionResult]::new('--profile', '--profile', [CompletionResultType]::ParameterName, 'The AWS profile to use to access the cluster')
+            [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, 'Name of the playbook saved locally')
+            [CompletionResult]::new('--filename', '--filename', [CompletionResultType]::ParameterName, 'Name of the playbook saved locally')
+            [CompletionResult]::new('-t', '-t', [CompletionResultType]::ParameterName, 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1')
+            [CompletionResult]::new('--target-version', '--target-version', [CompletionResultType]::ParameterName, 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1')
+            [CompletionResult]::new('--config', '--config', [CompletionResultType]::ParameterName, 'Path to an eksup configuration file (default: .eksup.yaml in cwd)')
+            [CompletionResult]::new('--ignore-recommended', '--ignore-recommended', [CompletionResultType]::ParameterName, 'Exclude recommendations from the output')
+            [CompletionResult]::new('-v', '-v', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('--verbose', '--verbose', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('-q', '-q', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
+            break
+        }
+        'eksup;create;help' {
+            [CompletionResult]::new('playbook', 'playbook', [CompletionResultType]::ParameterValue, 'Create a playbook for upgrading an Amazon EKS cluster')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
+            break
+        }
+        'eksup;create;help;playbook' {
+            break
+        }
+        'eksup;create;help;help' {
+            break
+        }
+        'eksup;completion' {
+            [CompletionResult]::new('-v', '-v', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('--verbose', '--verbose', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('-q', '-q', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
+            break
+        }
+        'eksup;man' {
+            [CompletionResult]::new('-v', '-v', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('--verbose', '--verbose', [CompletionResultType]::ParameterName, 'Increase logging verbosity')
+            [CompletionResult]::new('-q', '-q', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'Decrease logging verbosity')
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
+            break
+        }
+        'eksup;help' {
+            [CompletionResult]::new('analyze', 'analyze', [CompletionResultType]::ParameterValue, 'Analyze an Amazon EKS cluster for potential upgrade issues')
+            [CompletionResult]::new('create', 'create', [CompletionResultType]::ParameterValue, 'Create artifacts using the analysis data')
+            [CompletionResult]::new('completion', 'completion', [CompletionResultType]::ParameterValue, 'Generate shell completion script for the given shell')
+            [CompletionResult]::new('man', 'man', [CompletionResultType]::ParameterValue, 'Generate the man page for eksup')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
+            break
+        }
+        'eksup;help;analyze' {
+            break
+        }
+        'eksup;help;create' {
+            [CompletionResult]::new('playbook', 'playbook', [CompletionResultType]::ParameterValue, 'Create a playbook for upgrading an Amazon EKS cluster')
+            break
+        }
+        'eksup;help;create;playbook' {
+            break
+        }
+        'eksup;help;completion' {
+            break
+        }
+        'eksup;help;man' {
+            break
+        }
+        'eksup;help;help' {
+            break
+        }
+    })
+
+    $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
+        Sort-Object -Property ListItemText
+}

--- a/completions/eksup.bash
+++ b/completions/eksup.bash
@@ -1,0 +1,397 @@
+_eksup() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
+    cmd=""
+    opts=""
+
+    for i in "${COMP_WORDS[@]:0:COMP_CWORD}"
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="eksup"
+                ;;
+            eksup,analyze)
+                cmd="eksup__subcmd__analyze"
+                ;;
+            eksup,completion)
+                cmd="eksup__subcmd__completion"
+                ;;
+            eksup,create)
+                cmd="eksup__subcmd__create"
+                ;;
+            eksup,help)
+                cmd="eksup__subcmd__help"
+                ;;
+            eksup,man)
+                cmd="eksup__subcmd__man"
+                ;;
+            eksup__subcmd__create,help)
+                cmd="eksup__subcmd__create__subcmd__help"
+                ;;
+            eksup__subcmd__create,playbook)
+                cmd="eksup__subcmd__create__subcmd__playbook"
+                ;;
+            eksup__subcmd__create__subcmd__help,help)
+                cmd="eksup__subcmd__create__subcmd__help__subcmd__help"
+                ;;
+            eksup__subcmd__create__subcmd__help,playbook)
+                cmd="eksup__subcmd__create__subcmd__help__subcmd__playbook"
+                ;;
+            eksup__subcmd__help,analyze)
+                cmd="eksup__subcmd__help__subcmd__analyze"
+                ;;
+            eksup__subcmd__help,completion)
+                cmd="eksup__subcmd__help__subcmd__completion"
+                ;;
+            eksup__subcmd__help,create)
+                cmd="eksup__subcmd__help__subcmd__create"
+                ;;
+            eksup__subcmd__help,help)
+                cmd="eksup__subcmd__help__subcmd__help"
+                ;;
+            eksup__subcmd__help,man)
+                cmd="eksup__subcmd__help__subcmd__man"
+                ;;
+            eksup__subcmd__help__subcmd__create,playbook)
+                cmd="eksup__subcmd__help__subcmd__create__subcmd__playbook"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        eksup)
+            opts="-v -q -h -V --verbose --quiet --help --version analyze create completion man help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__analyze)
+            opts="-c -r -p -f -o -t -v -q -h -V --cluster --region --profile --format --output --target-version --ignore-recommended --config --verbose --quiet --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --cluster)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --region)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -r)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "json text" -- "${cur}"))
+                    return 0
+                    ;;
+                -f)
+                    COMPREPLY=($(compgen -W "json text" -- "${cur}"))
+                    return 0
+                    ;;
+                --output)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --target-version)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -t)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__completion)
+            opts="-v -q -h -V --verbose --quiet --help --version bash elvish fish powershell zsh"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__create)
+            opts="-v -q -h -V --verbose --quiet --help --version playbook help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__create__subcmd__help)
+            opts="playbook help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__create__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__create__subcmd__help__subcmd__playbook)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__create__subcmd__playbook)
+            opts="-c -r -p -f -t -v -q -h -V --cluster --region --profile --filename --target-version --ignore-recommended --config --verbose --quiet --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --cluster)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --region)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -r)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --filename)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -f)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --target-version)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -t)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__help)
+            opts="analyze create completion man help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__help__subcmd__analyze)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__help__subcmd__completion)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__help__subcmd__create)
+            opts="playbook"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__help__subcmd__create__subcmd__playbook)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__help__subcmd__man)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        eksup__subcmd__man)
+            opts="-v -q -h -V --verbose --quiet --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _eksup -o nosort -o bashdefault -o default eksup
+else
+    complete -F _eksup -o bashdefault -o default eksup
+fi

--- a/completions/eksup.elv
+++ b/completions/eksup.elv
@@ -1,0 +1,143 @@
+
+use builtin;
+use str;
+
+set edit:completion:arg-completer[eksup] = {|@words|
+    fn spaces {|n|
+        builtin:repeat $n ' ' | str:join ''
+    }
+    fn cand {|text desc|
+        edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
+    }
+    var command = 'eksup'
+    for word $words[1..-1] {
+        if (str:has-prefix $word '-') {
+            break
+        }
+        set command = $command';'$word
+    }
+    var completions = [
+        &'eksup'= {
+            cand -v 'Increase logging verbosity'
+            cand --verbose 'Increase logging verbosity'
+            cand -q 'Decrease logging verbosity'
+            cand --quiet 'Decrease logging verbosity'
+            cand -h 'Print help'
+            cand --help 'Print help'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand analyze 'Analyze an Amazon EKS cluster for potential upgrade issues'
+            cand create 'Create artifacts using the analysis data'
+            cand completion 'Generate shell completion script for the given shell'
+            cand man 'Generate the man page for eksup'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'eksup;analyze'= {
+            cand -c 'The name of the cluster to analyze'
+            cand --cluster 'The name of the cluster to analyze'
+            cand -r 'The AWS region where the cluster is provisioned'
+            cand --region 'The AWS region where the cluster is provisioned'
+            cand -p 'The AWS profile to use to access the cluster'
+            cand --profile 'The AWS profile to use to access the cluster'
+            cand -f 'f'
+            cand --format 'format'
+            cand -o 'Write to file instead of stdout'
+            cand --output 'Write to file instead of stdout'
+            cand -t 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1'
+            cand --target-version 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1'
+            cand --config 'Path to an eksup configuration file (default: .eksup.yaml in cwd)'
+            cand --ignore-recommended 'Exclude recommendations from the output'
+            cand -v 'Increase logging verbosity'
+            cand --verbose 'Increase logging verbosity'
+            cand -q 'Decrease logging verbosity'
+            cand --quiet 'Decrease logging verbosity'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'eksup;create'= {
+            cand -v 'Increase logging verbosity'
+            cand --verbose 'Increase logging verbosity'
+            cand -q 'Decrease logging verbosity'
+            cand --quiet 'Decrease logging verbosity'
+            cand -h 'Print help'
+            cand --help 'Print help'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand playbook 'Create a playbook for upgrading an Amazon EKS cluster'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'eksup;create;playbook'= {
+            cand -c 'The name of the cluster to analyze'
+            cand --cluster 'The name of the cluster to analyze'
+            cand -r 'The AWS region where the cluster is provisioned'
+            cand --region 'The AWS region where the cluster is provisioned'
+            cand -p 'The AWS profile to use to access the cluster'
+            cand --profile 'The AWS profile to use to access the cluster'
+            cand -f 'Name of the playbook saved locally'
+            cand --filename 'Name of the playbook saved locally'
+            cand -t 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1'
+            cand --target-version 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1'
+            cand --config 'Path to an eksup configuration file (default: .eksup.yaml in cwd)'
+            cand --ignore-recommended 'Exclude recommendations from the output'
+            cand -v 'Increase logging verbosity'
+            cand --verbose 'Increase logging verbosity'
+            cand -q 'Decrease logging verbosity'
+            cand --quiet 'Decrease logging verbosity'
+            cand -h 'Print help'
+            cand --help 'Print help'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'eksup;create;help'= {
+            cand playbook 'Create a playbook for upgrading an Amazon EKS cluster'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'eksup;create;help;playbook'= {
+        }
+        &'eksup;create;help;help'= {
+        }
+        &'eksup;completion'= {
+            cand -v 'Increase logging verbosity'
+            cand --verbose 'Increase logging verbosity'
+            cand -q 'Decrease logging verbosity'
+            cand --quiet 'Decrease logging verbosity'
+            cand -h 'Print help'
+            cand --help 'Print help'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'eksup;man'= {
+            cand -v 'Increase logging verbosity'
+            cand --verbose 'Increase logging verbosity'
+            cand -q 'Decrease logging verbosity'
+            cand --quiet 'Decrease logging verbosity'
+            cand -h 'Print help'
+            cand --help 'Print help'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'eksup;help'= {
+            cand analyze 'Analyze an Amazon EKS cluster for potential upgrade issues'
+            cand create 'Create artifacts using the analysis data'
+            cand completion 'Generate shell completion script for the given shell'
+            cand man 'Generate the man page for eksup'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'eksup;help;analyze'= {
+        }
+        &'eksup;help;create'= {
+            cand playbook 'Create a playbook for upgrading an Amazon EKS cluster'
+        }
+        &'eksup;help;create;playbook'= {
+        }
+        &'eksup;help;completion'= {
+        }
+        &'eksup;help;man'= {
+        }
+        &'eksup;help;help'= {
+        }
+    ]
+    $completions[$command]
+}

--- a/completions/eksup.fish
+++ b/completions/eksup.fish
@@ -1,0 +1,81 @@
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_eksup_global_optspecs
+	string join \n v/verbose q/quiet h/help V/version
+end
+
+function __fish_eksup_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_eksup_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_eksup_using_subcommand
+	set -l cmd (__fish_eksup_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c eksup -n "__fish_eksup_needs_command" -s v -l verbose -d 'Increase logging verbosity'
+complete -c eksup -n "__fish_eksup_needs_command" -s q -l quiet -d 'Decrease logging verbosity'
+complete -c eksup -n "__fish_eksup_needs_command" -s h -l help -d 'Print help'
+complete -c eksup -n "__fish_eksup_needs_command" -s V -l version -d 'Print version'
+complete -c eksup -n "__fish_eksup_needs_command" -f -a "analyze" -d 'Analyze an Amazon EKS cluster for potential upgrade issues'
+complete -c eksup -n "__fish_eksup_needs_command" -f -a "create" -d 'Create artifacts using the analysis data'
+complete -c eksup -n "__fish_eksup_needs_command" -f -a "completion" -d 'Generate shell completion script for the given shell'
+complete -c eksup -n "__fish_eksup_needs_command" -f -a "man" -d 'Generate the man page for eksup'
+complete -c eksup -n "__fish_eksup_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s c -l cluster -d 'The name of the cluster to analyze' -r
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s r -l region -d 'The AWS region where the cluster is provisioned' -r
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s p -l profile -d 'The AWS profile to use to access the cluster' -r
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s f -l format -r -f -a "json\t'JSON format used for logging or writing to a *.json file'
+text\t'Text format used for writing to stdout'"
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s o -l output -d 'Write to file instead of stdout' -r
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s t -l target-version -d 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1' -r
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -l config -d 'Path to an eksup configuration file (default: .eksup.yaml in cwd)' -r
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -l ignore-recommended -d 'Exclude recommendations from the output'
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s v -l verbose -d 'Increase logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s q -l quiet -d 'Decrease logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c eksup -n "__fish_eksup_using_subcommand analyze" -s V -l version -d 'Print version'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and not __fish_seen_subcommand_from playbook help" -s v -l verbose -d 'Increase logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and not __fish_seen_subcommand_from playbook help" -s q -l quiet -d 'Decrease logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and not __fish_seen_subcommand_from playbook help" -s h -l help -d 'Print help'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and not __fish_seen_subcommand_from playbook help" -s V -l version -d 'Print version'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and not __fish_seen_subcommand_from playbook help" -f -a "playbook" -d 'Create a playbook for upgrading an Amazon EKS cluster'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and not __fish_seen_subcommand_from playbook help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -s c -l cluster -d 'The name of the cluster to analyze' -r
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -s r -l region -d 'The AWS region where the cluster is provisioned' -r
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -s p -l profile -d 'The AWS profile to use to access the cluster' -r
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -s f -l filename -d 'Name of the playbook saved locally' -r
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -s t -l target-version -d 'Target Kubernetes version for the upgrade (e.g. "1.34"). Defaults to current + 1' -r
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -l config -d 'Path to an eksup configuration file (default: .eksup.yaml in cwd)' -r
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -l ignore-recommended -d 'Exclude recommendations from the output'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -s v -l verbose -d 'Increase logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -s q -l quiet -d 'Decrease logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -s h -l help -d 'Print help'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from playbook" -s V -l version -d 'Print version'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from help" -f -a "playbook" -d 'Create a playbook for upgrading an Amazon EKS cluster'
+complete -c eksup -n "__fish_eksup_using_subcommand create; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c eksup -n "__fish_eksup_using_subcommand completion" -s v -l verbose -d 'Increase logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand completion" -s q -l quiet -d 'Decrease logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand completion" -s h -l help -d 'Print help'
+complete -c eksup -n "__fish_eksup_using_subcommand completion" -s V -l version -d 'Print version'
+complete -c eksup -n "__fish_eksup_using_subcommand man" -s v -l verbose -d 'Increase logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand man" -s q -l quiet -d 'Decrease logging verbosity'
+complete -c eksup -n "__fish_eksup_using_subcommand man" -s h -l help -d 'Print help'
+complete -c eksup -n "__fish_eksup_using_subcommand man" -s V -l version -d 'Print version'
+complete -c eksup -n "__fish_eksup_using_subcommand help; and not __fish_seen_subcommand_from analyze create completion man help" -f -a "analyze" -d 'Analyze an Amazon EKS cluster for potential upgrade issues'
+complete -c eksup -n "__fish_eksup_using_subcommand help; and not __fish_seen_subcommand_from analyze create completion man help" -f -a "create" -d 'Create artifacts using the analysis data'
+complete -c eksup -n "__fish_eksup_using_subcommand help; and not __fish_seen_subcommand_from analyze create completion man help" -f -a "completion" -d 'Generate shell completion script for the given shell'
+complete -c eksup -n "__fish_eksup_using_subcommand help; and not __fish_seen_subcommand_from analyze create completion man help" -f -a "man" -d 'Generate the man page for eksup'
+complete -c eksup -n "__fish_eksup_using_subcommand help; and not __fish_seen_subcommand_from analyze create completion man help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c eksup -n "__fish_eksup_using_subcommand help; and __fish_seen_subcommand_from create" -f -a "playbook" -d 'Create a playbook for upgrading an Amazon EKS cluster'

--- a/docs/install/shell-completions.md
+++ b/docs/install/shell-completions.md
@@ -1,0 +1,81 @@
+# Shell Completions
+
+`eksup` supports shell completion for **bash**, **zsh**, **fish**, **powershell**, and **elvish**.
+
+## From the `eksup` binary
+
+If you have `eksup` installed (via `cargo install`, Homebrew, or any other method), generate the completion script with the `completion` subcommand and write it to your shell's completion directory.
+
+### Bash
+
+```sh
+eksup completion bash > /etc/bash_completion.d/eksup
+# or, for current user:
+eksup completion bash > ~/.local/share/bash-completion/completions/eksup
+```
+
+### Zsh
+
+```sh
+mkdir -p ~/.zfunc
+eksup completion zsh > ~/.zfunc/_eksup
+```
+
+Then ensure `~/.zfunc` is on your `fpath` in `~/.zshrc`:
+
+```sh
+fpath=(~/.zfunc $fpath)
+autoload -U compinit && compinit
+```
+
+### Fish
+
+```sh
+eksup completion fish > ~/.config/fish/completions/eksup.fish
+```
+
+### PowerShell
+
+```powershell
+eksup completion powershell | Out-String | Invoke-Expression
+```
+
+Or to persist across sessions, add the above to your `$PROFILE`.
+
+### Elvish
+
+```sh
+eksup completion elvish > ~/.config/elvish/lib/eksup.elv
+```
+
+Then `use eksup` in your `rc.elv`.
+
+## From a release tarball
+
+Release tarballs at <https://github.com/clowdhaus/eksup/releases> include pre-generated completion files under `completions/` and a man page at `man/eksup.1`. Most package managers (Homebrew, AUR, apt, etc.) install these to the appropriate system locations automatically.
+
+If installing manually:
+
+```sh
+# Bash (system-wide)
+sudo install -Dm644 completions/eksup.bash /etc/bash_completion.d/eksup
+
+# Zsh (per-user)
+install -Dm644 completions/_eksup ~/.zfunc/_eksup
+
+# Fish (per-user)
+install -Dm644 completions/eksup.fish ~/.config/fish/completions/eksup.fish
+
+# Man page
+sudo install -Dm644 man/eksup.1 /usr/local/share/man/man1/eksup.1
+```
+
+## Man page
+
+The same `eksup` binary can render its man page on demand:
+
+```sh
+eksup man > /usr/local/share/man/man1/eksup.1
+sudo mandb     # refresh man's index (Linux)
+man eksup
+```

--- a/docs/install/shell-completions.md
+++ b/docs/install/shell-completions.md
@@ -9,8 +9,11 @@ If you have `eksup` installed (via `cargo install`, Homebrew, or any other metho
 ### Bash
 
 ```sh
-eksup completion bash > /etc/bash_completion.d/eksup
-# or, for current user:
+# System-wide (requires root — `sudo` on the command alone won't work because
+# the shell redirect runs as your user, so pipe through `sudo tee` instead):
+eksup completion bash | sudo tee /etc/bash_completion.d/eksup > /dev/null
+
+# Or, for current user:
 eksup completion bash > ~/.local/share/bash-completion/completions/eksup
 ```
 

--- a/eksup/Cargo.toml
+++ b/eksup/Cargo.toml
@@ -33,6 +33,8 @@ aws-sdk-eks = { version = "1.131", default-features = false, features = ["rustls
 aws-sdk-servicequotas = { version = "1.101", default-features = false, features = ["rustls", "default-https-client", "rt-tokio"] }
 clap = { version = "4.6", default-features = false, features = ["std", "derive", "string", "color", "unstable-styles", "help", "usage", "error-context", "suggestions"] }
 clap-verbosity-flag = { version = "3.0", default-features = false, features = ["tracing"] }
+clap_complete = { version = "4.5", default-features = false }
+clap_mangen = { version = "0.2", default-features = false }
 indicatif = { version = "0.18", default-features = false, features = ["unicode-width"] }
 handlebars = { version = "6.4", default-features = false, features = ["rust-embed"] }
 # https://kube.rs/kubernetes-version/

--- a/eksup/src/analysis.rs
+++ b/eksup/src/analysis.rs
@@ -2,7 +2,12 @@ use anyhow::{Context, Result};
 use aws_sdk_eks::types::Cluster;
 use serde::{Deserialize, Serialize};
 
-use crate::{clients::{AwsClients, K8sClients}, eks, finding::Findings, k8s, version};
+use crate::{
+  clients::{AwsClients, K8sClients},
+  eks,
+  finding::Findings,
+  k8s, version,
+};
 
 /// Container of all findings collected
 #[derive(Debug, Serialize, Deserialize)]
@@ -19,32 +24,104 @@ pub struct Results {
 impl Results {
   /// Remove all findings where remediation is `Recommended`, keeping only `Required`
   pub fn filter_recommended(&mut self) {
-    self.cluster.cluster_health.retain(|f| !f.finding.remediation.is_recommended());
-    self.subnets.control_plane_ips.retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .cluster
+      .cluster_health
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .subnets
+      .control_plane_ips
+      .retain(|f| !f.finding.remediation.is_recommended());
     self.subnets.pod_ips.retain(|f| !f.finding.remediation.is_recommended());
     self.addons.health.retain(|f| !f.finding.remediation.is_recommended());
-    self.addons.version_compatibility.retain(|f| !f.finding.remediation.is_recommended());
-    self.data_plane.eks_managed_nodegroup_health.retain(|f| !f.finding.remediation.is_recommended());
-    self.data_plane.eks_managed_nodegroup_update.retain(|f| !f.finding.remediation.is_recommended());
-    self.data_plane.self_managed_nodegroup_update.retain(|f| !f.finding.remediation.is_recommended());
-    self.data_plane.al2_ami_deprecation.retain(|f| !f.finding.remediation.is_recommended());
-    self.data_plane.node_ips.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.version_skew.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.min_replicas.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.min_ready_seconds.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.pod_topology_distribution.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.readiness_probe.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.termination_grace_period.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.docker_socket.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.kube_proxy_version_skew.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.kube_proxy_ipvs_mode.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.ingress_nginx_retirement.retain(|f| !f.finding.remediation.is_recommended());
-    self.kubernetes.pod_disruption_budgets.retain(|f| !f.finding.remediation.is_recommended());
-    self.service_limits.ec2_limits.retain(|f| !f.finding.remediation.is_recommended());
-    self.service_limits.ebs_gp2_limits.retain(|f| !f.finding.remediation.is_recommended());
-    self.service_limits.ebs_gp3_limits.retain(|f| !f.finding.remediation.is_recommended());
-    self.insights.upgrade_readiness.retain(|f| !f.finding.remediation.is_recommended());
-    self.insights.misconfiguration.retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .addons
+      .version_compatibility
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .data_plane
+      .eks_managed_nodegroup_health
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .data_plane
+      .eks_managed_nodegroup_update
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .data_plane
+      .self_managed_nodegroup_update
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .data_plane
+      .al2_ami_deprecation
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .data_plane
+      .node_ips
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .version_skew
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .min_replicas
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .min_ready_seconds
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .pod_topology_distribution
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .readiness_probe
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .termination_grace_period
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .docker_socket
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .kube_proxy_version_skew
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .kube_proxy_ipvs_mode
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .ingress_nginx_retirement
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .kubernetes
+      .pod_disruption_budgets
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .service_limits
+      .ec2_limits
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .service_limits
+      .ebs_gp2_limits
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .service_limits
+      .ebs_gp3_limits
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .insights
+      .upgrade_readiness
+      .retain(|f| !f.finding.remediation.is_recommended());
+    self
+      .insights
+      .misconfiguration
+      .retain(|f| !f.finding.remediation.is_recommended());
   }
 
   /// Renders all findings as a formatted stdout table string
@@ -96,11 +173,24 @@ pub async fn analyze(
 
   let cluster_findings = eks::get_cluster_findings(cluster)?;
 
-  let (subnet_findings, addon_findings, dataplane_findings, kubernetes_findings, service_limit_findings, insights_findings) = tokio::try_join!(
+  let (
+    subnet_findings,
+    addon_findings,
+    dataplane_findings,
+    kubernetes_findings,
+    service_limit_findings,
+    insights_findings,
+  ) = tokio::try_join!(
     eks::get_subnet_findings(aws, k8s, cluster),
     eks::get_addon_findings(aws, cluster_name, cluster_version, target_minor),
     eks::get_data_plane_findings(aws, cluster, target_minor),
-    k8s::get_kubernetes_findings(k8s, control_plane_minor, target_minor, &config.checks.k8s002, &config.checks.k8s004),
+    k8s::get_kubernetes_findings(
+      k8s,
+      control_plane_minor,
+      target_minor,
+      &config.checks.k8s002,
+      &config.checks.k8s004
+    ),
     eks::get_service_limit_findings(aws),
     eks::get_insights_findings(aws, cluster_name),
   )?;

--- a/eksup/src/clients.rs
+++ b/eksup/src/clients.rs
@@ -11,23 +11,48 @@ use crate::{
 /// Trait abstracting all AWS API operations used by eksup
 pub trait AwsClients {
   fn get_cluster(&self, name: &str) -> impl std::future::Future<Output = Result<Cluster>> + Send;
-  fn get_subnet_ips(&self, subnet_ids: Vec<String>) -> impl std::future::Future<Output = Result<Vec<VpcSubnet>>> + Send;
+  fn get_subnet_ips(&self, subnet_ids: Vec<String>)
+  -> impl std::future::Future<Output = Result<Vec<VpcSubnet>>> + Send;
   fn get_addons(&self, cluster_name: &str) -> impl std::future::Future<Output = Result<Vec<Addon>>> + Send;
-  fn get_addon_versions(&self, name: &str, kubernetes_version: &str) -> impl std::future::Future<Output = Result<AddonVersion>> + Send;
-  fn get_eks_managed_nodegroups(&self, cluster_name: &str) -> impl std::future::Future<Output = Result<Vec<Nodegroup>>> + Send;
-  fn get_self_managed_nodegroups(&self, cluster_name: &str) -> impl std::future::Future<Output = Result<Vec<AutoScalingGroup>>> + Send;
-  fn get_fargate_profiles(&self, cluster_name: &str) -> impl std::future::Future<Output = Result<Vec<FargateProfile>>> + Send;
+  fn get_addon_versions(
+    &self,
+    name: &str,
+    kubernetes_version: &str,
+  ) -> impl std::future::Future<Output = Result<AddonVersion>> + Send;
+  fn get_eks_managed_nodegroups(
+    &self,
+    cluster_name: &str,
+  ) -> impl std::future::Future<Output = Result<Vec<Nodegroup>>> + Send;
+  fn get_self_managed_nodegroups(
+    &self,
+    cluster_name: &str,
+  ) -> impl std::future::Future<Output = Result<Vec<AutoScalingGroup>>> + Send;
+  fn get_fargate_profiles(
+    &self,
+    cluster_name: &str,
+  ) -> impl std::future::Future<Output = Result<Vec<FargateProfile>>> + Send;
   fn get_launch_template(&self, id: &str) -> impl std::future::Future<Output = Result<LaunchTemplate>> + Send;
-  fn get_service_quota_usage(&self, service_code: &str, quota_code: &str) -> impl std::future::Future<Output = Result<(String, f64, String)>> + Send;
+  fn get_service_quota_usage(
+    &self,
+    service_code: &str,
+    quota_code: &str,
+  ) -> impl std::future::Future<Output = Result<(String, f64, String)>> + Send;
   fn get_ec2_on_demand_vcpu_count(&self) -> impl std::future::Future<Output = Result<f64>> + Send;
   fn get_ebs_volume_storage(&self, volume_type: &str) -> impl std::future::Future<Output = Result<f64>> + Send;
-  fn get_cluster_insights(&self, cluster_name: &str) -> impl std::future::Future<Output = Result<Vec<ClusterInsight>>> + Send;
+  fn get_cluster_insights(
+    &self,
+    cluster_name: &str,
+  ) -> impl std::future::Future<Output = Result<Vec<ClusterInsight>>> + Send;
 }
 
 /// Trait abstracting all Kubernetes API operations used by eksup
 pub trait K8sClients {
   fn get_nodes(&self) -> impl std::future::Future<Output = Result<Vec<Node>>> + Send;
-  fn get_configmap(&self, namespace: &str, name: &str) -> impl std::future::Future<Output = Result<Option<ConfigMap>>> + Send;
+  fn get_configmap(
+    &self,
+    namespace: &str,
+    name: &str,
+  ) -> impl std::future::Future<Output = Result<Option<ConfigMap>>> + Send;
   fn get_eniconfigs(&self) -> impl std::future::Future<Output = Result<Vec<ENIConfig>>> + Send;
   fn get_resources(&self) -> impl std::future::Future<Output = Result<Vec<StdResource>>> + Send;
   fn get_pod_disruption_budgets(&self) -> impl std::future::Future<Output = Result<Vec<StdPdb>>> + Send;

--- a/eksup/src/config.rs
+++ b/eksup/src/config.rs
@@ -81,7 +81,11 @@ impl K8s002Config {
     }
 
     // Check overrides
-    if let Some(ovr) = self.overrides.iter().find(|o| o.name == name && o.namespace == namespace) {
+    if let Some(ovr) = self
+      .overrides
+      .iter()
+      .find(|o| o.name == name && o.namespace == namespace)
+    {
       return Some(ovr.min_replicas);
     }
 
@@ -121,7 +125,9 @@ impl Config {
       if ovr.min_replicas < 1 {
         anyhow::bail!(
           "K8S002.overrides[{}/{}].min_replicas must be >= 1, got {}",
-          ovr.namespace, ovr.name, ovr.min_replicas
+          ovr.namespace,
+          ovr.name,
+          ovr.min_replicas
         );
       }
     }
@@ -164,8 +170,9 @@ fn load_from(path: Option<&str>, base_dir: Option<&std::path::Path>) -> Result<C
 
 #[cfg(test)]
 mod tests {
-  use super::*;
   use std::io::Write;
+
+  use super::*;
 
   // ── Default values ──────────────────────────────────────────────────
 
@@ -255,7 +262,6 @@ mod tests {
         namespace: "other-ns".to_string(),
         min_replicas: 99,
       }],
-      ..Default::default()
     };
     assert_eq!(cfg.effective_min_replicas("my-app", "default"), Some(3));
   }

--- a/eksup/src/eks/checks.rs
+++ b/eksup/src/eks/checks.rs
@@ -91,7 +91,10 @@ pub struct InsufficientSubnetIps {
   pub available_ips: i32,
 }
 
-finding::impl_findings!(InsufficientSubnetIps, "✅ - There is sufficient IP space in the subnets provided");
+finding::impl_findings!(
+  InsufficientSubnetIps,
+  "✅ - There is sufficient IP space in the subnets provided"
+);
 
 pub(crate) fn control_plane_ips(subnet_ips: &[resources::VpcSubnet]) -> Vec<InsufficientSubnetIps> {
   let mut az_ips: std::collections::HashMap<String, i32> = std::collections::HashMap::new();
@@ -102,12 +105,7 @@ pub(crate) fn control_plane_ips(subnet_ips: &[resources::VpcSubnet]) -> Vec<Insu
   availability_zone_ips.sort_by(|a, b| a.0.cmp(&b.0));
 
   // There are at least 2 different availability zones with 5 or more IPs; no finding
-  if availability_zone_ips
-    .iter()
-    .filter(|(_az, ips)| ips >= &5)
-    .count()
-    >= 2
-  {
+  if availability_zone_ips.iter().filter(|(_az, ips)| ips >= &5).count() >= 2 {
     return vec![];
   }
 
@@ -241,7 +239,10 @@ pub struct AddonVersionCompatibility {
   pub target_kubernetes_version: resources::AddonVersion,
 }
 
-finding::impl_findings!(AddonVersionCompatibility, "✅ - There are no reported addon version compatibility issues.");
+finding::impl_findings!(
+  AddonVersionCompatibility,
+  "✅ - There are no reported addon version compatibility issues."
+);
 
 /// Check for any version compatibility issues for the EKS addons enabled
 pub(crate) fn addon_version_compatibility(
@@ -347,7 +348,10 @@ pub struct NodegroupHealthIssue {
   pub message: String,
 }
 
-finding::impl_findings!(NodegroupHealthIssue, "✅ - There are no reported nodegroup health issues.");
+finding::impl_findings!(
+  NodegroupHealthIssue,
+  "✅ - There are no reported nodegroup health issues."
+);
 
 /// Check for any reported health issues on EKS managed node groups
 pub(crate) fn eks_managed_nodegroup_health(nodegroups: &[Nodegroup]) -> Result<Vec<NodegroupHealthIssue>> {
@@ -396,7 +400,10 @@ pub struct ManagedNodeGroupUpdate {
   pub launch_template: resources::LaunchTemplate,
 }
 
-finding::impl_findings!(ManagedNodeGroupUpdate, "✅ - There are no pending updates for the EKS managed nodegroup(s)");
+finding::impl_findings!(
+  ManagedNodeGroupUpdate,
+  "✅ - There are no pending updates for the EKS managed nodegroup(s)"
+);
 
 pub(crate) fn eks_managed_nodegroup_update(
   nodegroup: &Nodegroup,
@@ -408,21 +415,17 @@ pub(crate) fn eks_managed_nodegroup_update(
   };
 
   match nodegroup.resources() {
-    Some(resources) => {
-      resources
-        .auto_scaling_groups()
-        .iter()
-        .map(|asg| {
-          ManagedNodeGroupUpdate {
-            finding: Finding::new(Code::EKS006, Remediation::Recommended),
-            name: nodegroup.nodegroup_name().unwrap_or_default().to_owned(),
-            autoscaling_group_name: asg.name().unwrap_or_default().to_owned(),
-            launch_template: launch_template.to_owned(),
-          }
-        })
-        .filter(|asg| asg.launch_template.current_version != asg.launch_template.latest_version)
-        .collect()
-    }
+    Some(resources) => resources
+      .auto_scaling_groups()
+      .iter()
+      .map(|asg| ManagedNodeGroupUpdate {
+        finding: Finding::new(Code::EKS006, Remediation::Recommended),
+        name: nodegroup.nodegroup_name().unwrap_or_default().to_owned(),
+        autoscaling_group_name: asg.name().unwrap_or_default().to_owned(),
+        launch_template: launch_template.to_owned(),
+      })
+      .filter(|asg| asg.launch_template.current_version != asg.launch_template.latest_version)
+      .collect(),
     None => vec![],
   }
 }
@@ -440,7 +443,10 @@ pub struct AutoscalingGroupUpdate {
   pub launch_template: resources::LaunchTemplate,
 }
 
-finding::impl_findings!(AutoscalingGroupUpdate, "✅ - There are no pending updates for the self-managed nodegroup(s)");
+finding::impl_findings!(
+  AutoscalingGroupUpdate,
+  "✅ - There are no pending updates for the self-managed nodegroup(s)"
+);
 
 /// Returns the autoscaling groups that are not using the latest launch template version
 ///
@@ -479,7 +485,10 @@ pub struct Al2AmiDeprecation {
   pub ami_type: String,
 }
 
-finding::impl_findings!(Al2AmiDeprecation, "✅ - No EKS managed nodegroups are using deprecated AL2 AMI types");
+finding::impl_findings!(
+  Al2AmiDeprecation,
+  "✅ - No EKS managed nodegroups are using deprecated AL2 AMI types"
+);
 
 /// Check for EKS managed nodegroups using AL2 AMI types which are deprecated in 1.32 and
 /// no longer supported starting in 1.33
@@ -501,7 +510,10 @@ pub(crate) fn al2_ami_deprecation(nodegroups: &[Nodegroup], target_minor: i32) -
       None => continue,
     };
 
-    let is_al2 = matches!(ami_type, AmiTypes::Al2X8664 | AmiTypes::Al2Arm64 | AmiTypes::Al2X8664Gpu);
+    let is_al2 = matches!(
+      ami_type,
+      AmiTypes::Al2X8664 | AmiTypes::Al2Arm64 | AmiTypes::Al2X8664Gpu
+    );
     if is_al2 {
       findings.push(Al2AmiDeprecation {
         finding: Finding::new(Code::EKS008, remediation.clone()),
@@ -529,7 +541,10 @@ pub struct ServiceLimitFinding {
   pub usage_pct: String,
 }
 
-finding::impl_findings!(ServiceLimitFinding, "✅ - Service limits have sufficient headroom for the upgrade");
+finding::impl_findings!(
+  ServiceLimitFinding,
+  "✅ - Service limits have sufficient headroom for the upgrade"
+);
 
 /// Check if a service quota usage is approaching or exceeding the limit
 pub(crate) fn service_limit(
@@ -588,9 +603,7 @@ finding::impl_findings!(InsightFinding, "✅ - No cluster insight issues found")
 /// Returns (upgrade_readiness, misconfiguration) tuples.
 /// PASSING insights are pre-filtered by the API call; this function
 /// maps ERROR → Required and WARNING/UNKNOWN → Recommended.
-pub(crate) fn cluster_insights(
-  insights: &[resources::ClusterInsight],
-) -> (Vec<InsightFinding>, Vec<InsightFinding>) {
+pub(crate) fn cluster_insights(insights: &[resources::ClusterInsight]) -> (Vec<InsightFinding>, Vec<InsightFinding>) {
   let mut upgrade_readiness = Vec::new();
   let mut misconfiguration = Vec::new();
 
@@ -628,19 +641,18 @@ pub(crate) fn cluster_insights(
 
 #[cfg(test)]
 mod tests {
-  use super::*;
   use aws_sdk_eks::types::{
-    Addon, AddonHealth, AddonIssue, AddonIssueCode, AmiTypes, Cluster, ClusterHealth, ClusterIssue,
-    ClusterIssueCode, Issue, Nodegroup, NodegroupHealth, NodegroupIssueCode,
+    Addon, AddonHealth, AddonIssue, AddonIssueCode, AmiTypes, Cluster, ClusterHealth, ClusterIssue, ClusterIssueCode,
+    Issue, Nodegroup, NodegroupHealth, NodegroupIssueCode,
   };
+
+  use super::*;
 
   // ---------- cluster_health ----------
 
   #[test]
   fn cluster_health_no_issues() {
-    let cluster = Cluster::builder()
-      .health(ClusterHealth::builder().build())
-      .build();
+    let cluster = Cluster::builder().health(ClusterHealth::builder().build()).build();
 
     let result = cluster_health(&cluster).unwrap();
     assert!(result.is_empty());
@@ -705,10 +717,7 @@ mod tests {
     assert_eq!(result[0].name, "vpc-cni");
     assert_eq!(result[0].code, "AccessDenied");
     assert_eq!(result[0].message, "Access denied");
-    assert_eq!(
-      result[0].resource_ids,
-      vec!["arn:aws:iam::123456789012:role/test"]
-    );
+    assert_eq!(result[0].resource_ids, vec!["arn:aws:iam::123456789012:role/test"]);
   }
 
   #[test]
@@ -789,10 +798,7 @@ mod tests {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].name, "test-ng");
     assert_eq!(result[0].ami_type, "AL2_x86_64");
-    assert!(matches!(
-      result[0].finding.remediation,
-      Remediation::Recommended
-    ));
+    assert!(matches!(result[0].finding.remediation, Remediation::Recommended));
   }
 
   #[test]
@@ -805,10 +811,7 @@ mod tests {
     let result = al2_ami_deprecation(&[ng], 33).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].name, "test-ng");
-    assert!(matches!(
-      result[0].finding.remediation,
-      Remediation::Required
-    ));
+    assert!(matches!(result[0].finding.remediation, Remediation::Required));
   }
 
   #[test]
@@ -852,15 +855,16 @@ mod tests {
       .ami_type(AmiTypes::BottlerocketX8664)
       .build();
 
-    let result =
-      al2_ami_deprecation(&[al2_ng, al2_arm_ng, al2023_ng, bottlerocket_ng], 32).unwrap();
+    let result = al2_ami_deprecation(&[al2_ng, al2_arm_ng, al2023_ng, bottlerocket_ng], 32).unwrap();
     // Only the two AL2 nodegroups should produce findings
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].name, "al2-ng");
     assert_eq!(result[1].name, "al2-arm-ng");
-    assert!(result
-      .iter()
-      .all(|f| matches!(f.finding.remediation, Remediation::Recommended)));
+    assert!(
+      result
+        .iter()
+        .all(|f| matches!(f.finding.remediation, Remediation::Recommended))
+    );
   }
 
   use crate::eks::resources::VpcSubnet;
@@ -876,8 +880,16 @@ mod tests {
   #[test]
   fn control_plane_ips_two_azs_sufficient() {
     let subnets = vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 10, availability_zone_id: "use1-az1".into() },
-      VpcSubnet { id: "subnet-2".into(), available_ips: 8, availability_zone_id: "use1-az2".into() },
+      VpcSubnet {
+        id: "subnet-1".into(),
+        available_ips: 10,
+        availability_zone_id: "use1-az1".into(),
+      },
+      VpcSubnet {
+        id: "subnet-2".into(),
+        available_ips: 8,
+        availability_zone_id: "use1-az2".into(),
+      },
     ];
     let result = control_plane_ips(&subnets);
     assert!(result.is_empty(), "2 AZs with >= 5 IPs should produce no findings");
@@ -886,19 +898,39 @@ mod tests {
   #[test]
   fn control_plane_ips_one_az_insufficient() {
     let subnets = vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 10, availability_zone_id: "use1-az1".into() },
-      VpcSubnet { id: "subnet-2".into(), available_ips: 3, availability_zone_id: "use1-az2".into() },
+      VpcSubnet {
+        id: "subnet-1".into(),
+        available_ips: 10,
+        availability_zone_id: "use1-az1".into(),
+      },
+      VpcSubnet {
+        id: "subnet-2".into(),
+        available_ips: 3,
+        availability_zone_id: "use1-az2".into(),
+      },
     ];
     let result = control_plane_ips(&subnets);
     assert!(!result.is_empty(), "only 1 AZ with >= 5 IPs should produce findings");
-    assert!(result.iter().all(|f| matches!(f.finding.remediation, Remediation::Required)));
+    assert!(
+      result
+        .iter()
+        .all(|f| matches!(f.finding.remediation, Remediation::Required))
+    );
   }
 
   #[test]
   fn control_plane_ips_boundary_exactly_5() {
     let subnets = vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 5, availability_zone_id: "use1-az1".into() },
-      VpcSubnet { id: "subnet-2".into(), available_ips: 5, availability_zone_id: "use1-az2".into() },
+      VpcSubnet {
+        id: "subnet-1".into(),
+        available_ips: 5,
+        availability_zone_id: "use1-az1".into(),
+      },
+      VpcSubnet {
+        id: "subnet-2".into(),
+        available_ips: 5,
+        availability_zone_id: "use1-az2".into(),
+      },
     ];
     let result = control_plane_ips(&subnets);
     assert!(result.is_empty(), "exactly 5 IPs in 2 AZs should pass");
@@ -907,9 +939,21 @@ mod tests {
   #[test]
   fn control_plane_ips_aggregates_across_subnets_in_same_az() {
     let subnets = vec![
-      VpcSubnet { id: "subnet-1a".into(), available_ips: 3, availability_zone_id: "use1-az1".into() },
-      VpcSubnet { id: "subnet-1b".into(), available_ips: 3, availability_zone_id: "use1-az1".into() },
-      VpcSubnet { id: "subnet-2".into(), available_ips: 6, availability_zone_id: "use1-az2".into() },
+      VpcSubnet {
+        id: "subnet-1a".into(),
+        available_ips: 3,
+        availability_zone_id: "use1-az1".into(),
+      },
+      VpcSubnet {
+        id: "subnet-1b".into(),
+        available_ips: 3,
+        availability_zone_id: "use1-az1".into(),
+      },
+      VpcSubnet {
+        id: "subnet-2".into(),
+        available_ips: 6,
+        availability_zone_id: "use1-az2".into(),
+      },
     ];
     let result = control_plane_ips(&subnets);
     assert!(result.is_empty(), "3+3=6 in az1 and 6 in az2 should pass");
@@ -926,8 +970,16 @@ mod tests {
   #[test]
   fn pod_ips_above_recommended() {
     let subnets = vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 200, availability_zone_id: "use1-az1".into() },
-      VpcSubnet { id: "subnet-2".into(), available_ips: 100, availability_zone_id: "use1-az2".into() },
+      VpcSubnet {
+        id: "subnet-1".into(),
+        available_ips: 200,
+        availability_zone_id: "use1-az1".into(),
+      },
+      VpcSubnet {
+        id: "subnet-2".into(),
+        available_ips: 100,
+        availability_zone_id: "use1-az2".into(),
+      },
     ];
     let result = pod_ips(&subnets, 16, 256);
     assert!(result.is_empty(), "300 IPs >= 256 recommended threshold");
@@ -935,22 +987,34 @@ mod tests {
 
   #[test]
   fn pod_ips_between_required_and_recommended() {
-    let subnets = vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 100, availability_zone_id: "use1-az1".into() },
-    ];
+    let subnets = vec![VpcSubnet {
+      id: "subnet-1".into(),
+      available_ips: 100,
+      availability_zone_id: "use1-az1".into(),
+    }];
     let result = pod_ips(&subnets, 16, 256);
     assert!(!result.is_empty());
-    assert!(result.iter().all(|f| matches!(f.finding.remediation, Remediation::Recommended)));
+    assert!(
+      result
+        .iter()
+        .all(|f| matches!(f.finding.remediation, Remediation::Recommended))
+    );
   }
 
   #[test]
   fn pod_ips_below_required() {
-    let subnets = vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 10, availability_zone_id: "use1-az1".into() },
-    ];
+    let subnets = vec![VpcSubnet {
+      id: "subnet-1".into(),
+      available_ips: 10,
+      availability_zone_id: "use1-az1".into(),
+    }];
     let result = pod_ips(&subnets, 16, 256);
     assert!(!result.is_empty());
-    assert!(result.iter().all(|f| matches!(f.finding.remediation, Remediation::Required)));
+    assert!(
+      result
+        .iter()
+        .all(|f| matches!(f.finding.remediation, Remediation::Required))
+    );
   }
 
   // ---------- data_plane_ips ----------
@@ -964,8 +1028,16 @@ mod tests {
   #[test]
   fn data_plane_ips_above_recommended() {
     let subnets = vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 80, availability_zone_id: "use1-az1".into() },
-      VpcSubnet { id: "subnet-2".into(), available_ips: 80, availability_zone_id: "use1-az2".into() },
+      VpcSubnet {
+        id: "subnet-1".into(),
+        available_ips: 80,
+        availability_zone_id: "use1-az1".into(),
+      },
+      VpcSubnet {
+        id: "subnet-2".into(),
+        available_ips: 80,
+        availability_zone_id: "use1-az2".into(),
+      },
     ];
     let result = data_plane_ips(&subnets, 30, 100);
     assert!(result.is_empty());
@@ -973,68 +1045,90 @@ mod tests {
 
   #[test]
   fn data_plane_ips_between_required_and_recommended() {
-    let subnets = vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 40, availability_zone_id: "use1-az1".into() },
-    ];
+    let subnets = vec![VpcSubnet {
+      id: "subnet-1".into(),
+      available_ips: 40,
+      availability_zone_id: "use1-az1".into(),
+    }];
     let result = data_plane_ips(&subnets, 30, 100);
     assert!(!result.is_empty());
-    assert!(result.iter().all(|f| matches!(f.finding.remediation, Remediation::Recommended)));
+    assert!(
+      result
+        .iter()
+        .all(|f| matches!(f.finding.remediation, Remediation::Recommended))
+    );
   }
 
   #[test]
   fn data_plane_ips_below_required() {
-    let subnets = vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 10, availability_zone_id: "use1-az1".into() },
-    ];
+    let subnets = vec![VpcSubnet {
+      id: "subnet-1".into(),
+      available_ips: 10,
+      availability_zone_id: "use1-az1".into(),
+    }];
     let result = data_plane_ips(&subnets, 30, 100);
     assert!(!result.is_empty());
-    assert!(result.iter().all(|f| matches!(f.finding.remediation, Remediation::Required)));
+    assert!(
+      result
+        .iter()
+        .all(|f| matches!(f.finding.remediation, Remediation::Required))
+    );
   }
 
   // ---------- addon_version_compatibility ----------
 
   use std::collections::{HashMap as StdHashMap, HashSet};
+
   use crate::eks::resources::AddonVersion;
 
   #[test]
   fn addon_version_compat_all_supported() {
-    let addon = Addon::builder()
-      .addon_name("vpc-cni")
-      .addon_version("v1.15.0")
-      .build();
+    let addon = Addon::builder().addon_name("vpc-cni").addon_version("v1.15.0").build();
 
-    let current = StdHashMap::from([("vpc-cni".into(), AddonVersion {
-      latest: "v1.15.0".into(),
-      default: "v1.14.0".into(),
-      supported_versions: HashSet::from(["v1.15.0".into(), "v1.14.0".into()]),
-    })]);
-    let target = StdHashMap::from([("vpc-cni".into(), AddonVersion {
-      latest: "v1.16.0".into(),
-      default: "v1.15.0".into(),
-      supported_versions: HashSet::from(["v1.16.0".into(), "v1.15.0".into()]),
-    })]);
+    let current = StdHashMap::from([(
+      "vpc-cni".into(),
+      AddonVersion {
+        latest: "v1.15.0".into(),
+        default: "v1.14.0".into(),
+        supported_versions: HashSet::from(["v1.15.0".into(), "v1.14.0".into()]),
+      },
+    )]);
+    let target = StdHashMap::from([(
+      "vpc-cni".into(),
+      AddonVersion {
+        latest: "v1.16.0".into(),
+        default: "v1.15.0".into(),
+        supported_versions: HashSet::from(["v1.16.0".into(), "v1.15.0".into()]),
+      },
+    )]);
 
     let result = addon_version_compatibility(&[addon], &current, &target);
-    assert!(result.is_empty(), "version supported in both should produce no findings");
+    assert!(
+      result.is_empty(),
+      "version supported in both should produce no findings"
+    );
   }
 
   #[test]
   fn addon_version_compat_not_latest_recommended() {
-    let addon = Addon::builder()
-      .addon_name("vpc-cni")
-      .addon_version("v1.14.0")
-      .build();
+    let addon = Addon::builder().addon_name("vpc-cni").addon_version("v1.14.0").build();
 
-    let current = StdHashMap::from([("vpc-cni".into(), AddonVersion {
-      latest: "v1.15.0".into(),
-      default: "v1.14.0".into(),
-      supported_versions: HashSet::from(["v1.15.0".into(), "v1.14.0".into()]),
-    })]);
-    let target = StdHashMap::from([("vpc-cni".into(), AddonVersion {
-      latest: "v1.16.0".into(),
-      default: "v1.15.0".into(),
-      supported_versions: HashSet::from(["v1.16.0".into(), "v1.15.0".into(), "v1.14.0".into()]),
-    })]);
+    let current = StdHashMap::from([(
+      "vpc-cni".into(),
+      AddonVersion {
+        latest: "v1.15.0".into(),
+        default: "v1.14.0".into(),
+        supported_versions: HashSet::from(["v1.15.0".into(), "v1.14.0".into()]),
+      },
+    )]);
+    let target = StdHashMap::from([(
+      "vpc-cni".into(),
+      AddonVersion {
+        latest: "v1.16.0".into(),
+        default: "v1.15.0".into(),
+        supported_versions: HashSet::from(["v1.16.0".into(), "v1.15.0".into(), "v1.14.0".into()]),
+      },
+    )]);
 
     let result = addon_version_compatibility(&[addon], &current, &target);
     assert_eq!(result.len(), 1);
@@ -1043,21 +1137,24 @@ mod tests {
 
   #[test]
   fn addon_version_compat_unsupported_on_target_required() {
-    let addon = Addon::builder()
-      .addon_name("vpc-cni")
-      .addon_version("v1.12.0")
-      .build();
+    let addon = Addon::builder().addon_name("vpc-cni").addon_version("v1.12.0").build();
 
-    let current = StdHashMap::from([("vpc-cni".into(), AddonVersion {
-      latest: "v1.15.0".into(),
-      default: "v1.14.0".into(),
-      supported_versions: HashSet::from(["v1.15.0".into(), "v1.14.0".into(), "v1.12.0".into()]),
-    })]);
-    let target = StdHashMap::from([("vpc-cni".into(), AddonVersion {
-      latest: "v1.16.0".into(),
-      default: "v1.15.0".into(),
-      supported_versions: HashSet::from(["v1.16.0".into(), "v1.15.0".into()]),
-    })]);
+    let current = StdHashMap::from([(
+      "vpc-cni".into(),
+      AddonVersion {
+        latest: "v1.15.0".into(),
+        default: "v1.14.0".into(),
+        supported_versions: HashSet::from(["v1.15.0".into(), "v1.14.0".into(), "v1.12.0".into()]),
+      },
+    )]);
+    let target = StdHashMap::from([(
+      "vpc-cni".into(),
+      AddonVersion {
+        latest: "v1.16.0".into(),
+        default: "v1.15.0".into(),
+        supported_versions: HashSet::from(["v1.16.0".into(), "v1.15.0".into()]),
+      },
+    )]);
 
     let result = addon_version_compatibility(&[addon], &current, &target);
     assert_eq!(result.len(), 1);
@@ -1067,6 +1164,7 @@ mod tests {
   // ---------- eks_managed_nodegroup_update ----------
 
   use aws_sdk_eks::types::{AutoScalingGroup as EksAutoScalingGroup, NodegroupResources};
+
   use crate::eks::resources::LaunchTemplate;
 
   #[test]
@@ -1082,10 +1180,8 @@ mod tests {
       .nodegroup_name("test")
       .resources(
         NodegroupResources::builder()
-          .auto_scaling_groups(
-            EksAutoScalingGroup::builder().name("asg-1").build()
-          )
-          .build()
+          .auto_scaling_groups(EksAutoScalingGroup::builder().name("asg-1").build())
+          .build(),
       )
       .build();
     let lt = LaunchTemplate {
@@ -1104,10 +1200,8 @@ mod tests {
       .nodegroup_name("test")
       .resources(
         NodegroupResources::builder()
-          .auto_scaling_groups(
-            EksAutoScalingGroup::builder().name("asg-1").build()
-          )
-          .build()
+          .auto_scaling_groups(EksAutoScalingGroup::builder().name("asg-1").build())
+          .build(),
       )
       .build();
     let lt = LaunchTemplate {
@@ -1125,9 +1219,7 @@ mod tests {
 
   #[test]
   fn smng_update_current_equals_latest() {
-    let asg = AutoScalingGroup::builder()
-      .auto_scaling_group_name("asg-1")
-      .build();
+    let asg = AutoScalingGroup::builder().auto_scaling_group_name("asg-1").build();
     let lt = LaunchTemplate {
       name: "lt-1".into(),
       id: "lt-abc".into(),
@@ -1140,9 +1232,7 @@ mod tests {
 
   #[test]
   fn smng_update_current_behind_latest() {
-    let asg = AutoScalingGroup::builder()
-      .auto_scaling_group_name("asg-1")
-      .build();
+    let asg = AutoScalingGroup::builder().auto_scaling_group_name("asg-1").build();
     let lt = LaunchTemplate {
       name: "lt-1".into(),
       id: "lt-abc".into(),

--- a/eksup/src/eks/findings.rs
+++ b/eksup/src/eks/findings.rs
@@ -156,7 +156,9 @@ pub async fn get_data_plane_findings(
     let lt_spec = self_mng
       .launch_template()
       .context("Launch template not found, launch configuration is not supported")?;
-    let lt = aws.get_launch_template(lt_spec.launch_template_id().unwrap_or_default()).await?;
+    let lt = aws
+      .get_launch_template(lt_spec.launch_template_id().unwrap_or_default())
+      .await?;
     if let Some(update) = checks::self_managed_nodegroup_update(self_mng, &lt) {
       self_managed_nodegroup_update.push(update);
     }
@@ -196,10 +198,9 @@ pub async fn get_service_limit_findings(aws: &impl AwsClients) -> Result<Service
     aws.get_service_quota_usage("ec2", quota_codes::EC2_ON_DEMAND_STANDARD),
     aws.get_ec2_on_demand_vcpu_count(),
   ) {
-    Ok(((name, limit, unit), current)) => {
-      checks::service_limit(Code::AWS003, &name, current, limit, &unit)
-        .into_iter().collect()
-    }
+    Ok(((name, limit, unit), current)) => checks::service_limit(Code::AWS003, &name, current, limit, &unit)
+      .into_iter()
+      .collect(),
     Err(e) => {
       tracing::warn!("Unable to check EC2 service limits: {e}");
       vec![]
@@ -211,10 +212,9 @@ pub async fn get_service_limit_findings(aws: &impl AwsClients) -> Result<Service
     aws.get_service_quota_usage("ebs", quota_codes::EBS_GP2_STORAGE),
     aws.get_ebs_volume_storage("gp2"),
   ) {
-    Ok(((name, limit, unit), current)) => {
-      checks::service_limit(Code::AWS004, &name, current, limit, &unit)
-        .into_iter().collect()
-    }
+    Ok(((name, limit, unit), current)) => checks::service_limit(Code::AWS004, &name, current, limit, &unit)
+      .into_iter()
+      .collect(),
     Err(e) => {
       tracing::warn!("Unable to check EBS GP2 service limits: {e}");
       vec![]
@@ -226,10 +226,9 @@ pub async fn get_service_limit_findings(aws: &impl AwsClients) -> Result<Service
     aws.get_service_quota_usage("ebs", quota_codes::EBS_GP3_STORAGE),
     aws.get_ebs_volume_storage("gp3"),
   ) {
-    Ok(((name, limit, unit), current)) => {
-      checks::service_limit(Code::AWS005, &name, current, limit, &unit)
-        .into_iter().collect()
-    }
+    Ok(((name, limit, unit), current)) => checks::service_limit(Code::AWS005, &name, current, limit, &unit)
+      .into_iter()
+      .collect(),
     Err(e) => {
       tracing::warn!("Unable to check EBS GP3 service limits: {e}");
       vec![]
@@ -249,10 +248,7 @@ pub struct InsightsFindings {
   pub misconfiguration: Vec<checks::InsightFinding>,
 }
 
-pub async fn get_insights_findings(
-  aws: &impl AwsClients,
-  cluster_name: &str,
-) -> Result<InsightsFindings> {
+pub async fn get_insights_findings(aws: &impl AwsClients, cluster_name: &str) -> Result<InsightsFindings> {
   let insights = aws.get_cluster_insights(cluster_name).await?;
   let (upgrade_readiness, misconfiguration) = checks::cluster_insights(&insights);
 

--- a/eksup/src/eks/mod.rs
+++ b/eksup/src/eks/mod.rs
@@ -3,7 +3,7 @@ pub mod findings;
 pub mod resources;
 
 pub use findings::{
-  AddonFindings, ClusterFindings, DataPlaneFindings, InsightsFindings, ServiceLimitFindings,
-  SubnetFindings, get_addon_findings, get_cluster_findings, get_data_plane_findings,
-  get_insights_findings, get_service_limit_findings, get_subnet_findings,
+  AddonFindings, ClusterFindings, DataPlaneFindings, InsightsFindings, ServiceLimitFindings, SubnetFindings,
+  get_addon_findings, get_cluster_findings, get_data_plane_findings, get_insights_findings, get_service_limit_findings,
+  get_subnet_findings,
 };

--- a/eksup/src/eks/resources.rs
+++ b/eksup/src/eks/resources.rs
@@ -6,11 +6,11 @@ use aws_sdk_autoscaling::{
   types::{AutoScalingGroup, Filter as AsgFilter},
 };
 use aws_sdk_ec2::Client as Ec2Client;
-use aws_sdk_servicequotas::Client as SqClient;
 use aws_sdk_eks::{
   Client as EksClient,
   types::{Addon, Cluster, FargateProfile, Nodegroup},
 };
+use aws_sdk_servicequotas::Client as SqClient;
 use serde::{Deserialize, Serialize};
 use tabled::Tabled;
 
@@ -23,7 +23,9 @@ pub async fn get_cluster(client: &EksClient, name: &str) -> Result<Cluster> {
     .await
     .context(format!("Cluster '{name}' not found"))?;
 
-  response.cluster.context(format!("Cluster '{name}' not found in response"))
+  response
+    .cluster
+    .context(format!("Cluster '{name}' not found in response"))
 }
 
 /// Container for the subnet IDs and their total available IPs
@@ -121,11 +123,7 @@ pub struct AddonVersion {
 ///
 /// Returns associated version details for a given addon that, primarily used
 /// for version compatibility checks and/or upgrade recommendations
-pub async fn get_addon_versions(
-  client: &EksClient,
-  name: &str,
-  kubernetes_version: &str,
-) -> Result<AddonVersion> {
+pub async fn get_addon_versions(client: &EksClient, name: &str, kubernetes_version: &str) -> Result<AddonVersion> {
   // Get all of the addon versions supported for the given addon and Kubernetes version
   let describe = client
     .describe_addon_versions()
@@ -133,14 +131,20 @@ pub async fn get_addon_versions(
     .kubernetes_version(kubernetes_version)
     .send()
     .await
-    .context(format!("Failed to describe addon versions for '{name}' on Kubernetes {kubernetes_version}"))?;
+    .context(format!(
+      "Failed to describe addon versions for '{name}' on Kubernetes {kubernetes_version}"
+    ))?;
 
   // Since we are providing an addon name, we are only concerned with the first and only item
-  let addon = describe.addons().first()
-    .context(format!("No addon found for '{name}' on Kubernetes version '{kubernetes_version}'"))?;
-  let latest_version = addon.addon_versions().first()
+  let addon = describe.addons().first().context(format!(
+    "No addon found for '{name}' on Kubernetes version '{kubernetes_version}'"
+  ))?;
+  let latest_version = addon
+    .addon_versions()
+    .first()
     .context(format!("No addon versions found for addon '{name}'"))?
-    .addon_version().unwrap_or_default();
+    .addon_version()
+    .unwrap_or_default();
 
   // The default version as specified by the EKS API for a given addon and Kubernetes version
   let default_version = addon
@@ -213,17 +217,28 @@ pub async fn get_self_managed_nodegroups(client: &AsgClient, cluster_name: &str)
     .set_values(Some(keys))
     .build();
 
-  let response = client.describe_auto_scaling_groups().filters(filter).send().await
-    .context(format!("Failed to describe Auto Scaling groups for cluster '{cluster_name}'"))?;
+  let response = client
+    .describe_auto_scaling_groups()
+    .filters(filter)
+    .send()
+    .await
+    .context(format!(
+      "Failed to describe Auto Scaling groups for cluster '{cluster_name}'"
+    ))?;
   let groups = response.auto_scaling_groups().to_owned();
 
   // Filter out EKS managed node groups by the EKS MNG applied tag
-  Ok(groups.into_iter().filter(|group| {
-    group
-      .tags()
-      .iter()
-      .all(|tag| tag.key().unwrap_or_default() != "eks:nodegroup-name")
-  }).collect())
+  Ok(
+    groups
+      .into_iter()
+      .filter(|group| {
+        group
+          .tags()
+          .iter()
+          .all(|tag| tag.key().unwrap_or_default() != "eks:nodegroup-name")
+      })
+      .collect(),
+  )
 }
 
 pub async fn get_fargate_profiles(client: &EksClient, cluster_name: &str) -> Result<Vec<FargateProfile>> {
@@ -328,14 +343,12 @@ pub async fn get_ec2_on_demand_vcpu_count(client: &Ec2Client) -> Result<f64> {
   let mut next_token: Option<String> = None;
 
   loop {
-    let mut req = client
-      .describe_instances()
-      .filters(
-        aws_sdk_ec2::types::Filter::builder()
-          .name("instance-state-name")
-          .values("running")
-          .build(),
-      );
+    let mut req = client.describe_instances().filters(
+      aws_sdk_ec2::types::Filter::builder()
+        .name("instance-state-name")
+        .values("running")
+        .build(),
+    );
     if let Some(token) = &next_token {
       req = req.next_token(token);
     }
@@ -370,18 +383,19 @@ pub async fn get_ebs_volume_storage(client: &Ec2Client, volume_type: &str) -> Re
   let mut next_token: Option<String> = None;
 
   loop {
-    let mut req = client
-      .describe_volumes()
-      .filters(
-        aws_sdk_ec2::types::Filter::builder()
-          .name("volume-type")
-          .values(volume_type)
-          .build(),
-      );
+    let mut req = client.describe_volumes().filters(
+      aws_sdk_ec2::types::Filter::builder()
+        .name("volume-type")
+        .values(volume_type)
+        .build(),
+    );
     if let Some(token) = &next_token {
       req = req.next_token(token);
     }
-    let resp = req.send().await.context(format!("Failed to describe {volume_type} EBS volumes"))?;
+    let resp = req
+      .send()
+      .await
+      .context(format!("Failed to describe {volume_type} EBS volumes"))?;
 
     for volume in resp.volumes() {
       total_gib += volume.size.unwrap_or(0) as f64;
@@ -405,7 +419,8 @@ pub async fn get_launch_template(client: &Ec2Client, id: &str) -> Result<LaunchT
     .await
     .context(format!("Failed to describe launch template '{id}'"))?;
 
-  let lts = output.launch_templates
+  let lts = output
+    .launch_templates
     .context(format!("No launch templates found for id '{id}'"))?;
 
   lts
@@ -446,10 +461,7 @@ pub async fn list_insights(client: &EksClient, cluster_name: &str) -> Result<Vec
   let mut insight_ids = Vec::new();
   let mut next_token: Option<String> = None;
   loop {
-    let mut req = client
-      .list_insights()
-      .cluster_name(cluster_name)
-      .filter(filter.clone());
+    let mut req = client.list_insights().cluster_name(cluster_name).filter(filter.clone());
     if let Some(token) = &next_token {
       req = req.next_token(token);
     }
@@ -471,11 +483,7 @@ pub async fn list_insights(client: &EksClient, cluster_name: &str) -> Result<Vec
 }
 
 /// Describe a single cluster insight by ID
-pub async fn describe_insight(
-  client: &EksClient,
-  cluster_name: &str,
-  insight_id: &str,
-) -> Result<ClusterInsight> {
+pub async fn describe_insight(client: &EksClient, cluster_name: &str, insight_id: &str) -> Result<ClusterInsight> {
   let resp = client
     .describe_insight()
     .cluster_name(cluster_name)
@@ -507,10 +515,7 @@ pub async fn describe_insight(
 }
 
 /// Fetch all non-PASSING cluster insights with full details
-pub async fn get_cluster_insights(
-  client: &EksClient,
-  cluster_name: &str,
-) -> Result<Vec<ClusterInsight>> {
+pub async fn get_cluster_insights(client: &EksClient, cluster_name: &str) -> Result<Vec<ClusterInsight>> {
   let insight_ids = list_insights(client, cluster_name).await?;
 
   let mut insights = Vec::new();

--- a/eksup/src/finding.rs
+++ b/eksup/src/finding.rs
@@ -76,7 +76,9 @@ macro_rules! impl_findings {
 
         let mut table = ::tabled::Table::new(self);
         table
-          .with(::tabled::settings::Remove::column(::tabled::settings::location::ByColumnName::new("CHECK")))
+          .with(::tabled::settings::Remove::column(
+            ::tabled::settings::location::ByColumnName::new("CHECK"),
+          ))
           .with(::tabled::settings::Margin::new(1, 0, 0, 0).fill('\t', 'x', 'x', 'x'))
           .with(::tabled::settings::Style::markdown());
 
@@ -242,8 +244,13 @@ mod tests {
   #[test]
   fn always_relevant_codes_apply_to_any_version() {
     let always = [
-      Code::AWS001, Code::AWS002, Code::EKS001, Code::K8S001,
-      Code::K8S002, Code::K8S008, Code::K8S011,
+      Code::AWS001,
+      Code::AWS002,
+      Code::EKS001,
+      Code::K8S001,
+      Code::K8S002,
+      Code::K8S008,
+      Code::K8S011,
     ];
     for code in &always {
       assert!(code.is_applicable(30), "{code} should be applicable at 1.30");
@@ -269,15 +276,27 @@ mod tests {
 
   #[test]
   fn code_description() {
-    assert_eq!(Code::AWS001.description(), "Insufficient available subnet IPs for nodes");
-    assert_eq!(Code::EKS008.description(), "AL2 AMI deprecation (deprecated in 1.32, removed in 1.33+)");
+    assert_eq!(
+      Code::AWS001.description(),
+      "Insufficient available subnet IPs for nodes"
+    );
+    assert_eq!(
+      Code::EKS008.description(),
+      "AL2 AMI deprecation (deprecated in 1.32, removed in 1.33+)"
+    );
     assert!(Code::K8S009.description().contains("Pod security policies"));
   }
 
   #[test]
   fn code_url() {
-    assert_eq!(Code::AWS001.url(), "https://clowdhaus.github.io/eksup/info/checks/#aws001");
-    assert_eq!(Code::K8S013.url(), "https://clowdhaus.github.io/eksup/info/checks/#k8s013");
+    assert_eq!(
+      Code::AWS001.url(),
+      "https://clowdhaus.github.io/eksup/info/checks/#aws001"
+    );
+    assert_eq!(
+      Code::K8S013.url(),
+      "https://clowdhaus.github.io/eksup/info/checks/#k8s013"
+    );
   }
 
   #[test]

--- a/eksup/src/k8s/checks.rs
+++ b/eksup/src/k8s/checks.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
 
 use anyhow::{Context, Result};
+use k8s_openapi::api::core::v1::ConfigMap;
 use serde::{Deserialize, Serialize};
 use tabled::{
   Table, Tabled,
   settings::{Margin, Remove, Style, location::ByColumnName},
 };
-
-use k8s_openapi::api::core::v1::ConfigMap;
 
 use crate::{
   finding::{self, Code, Finding, Findings, Remediation},
@@ -143,7 +142,10 @@ pub struct MinReplicas {
   pub replicas: i32,
 }
 
-finding::impl_findings!(MinReplicas, "✅ - All relevant Kubernetes workloads meet the configured minimum replicas");
+finding::impl_findings!(
+  MinReplicas,
+  "✅ - All relevant Kubernetes workloads meet the configured minimum replicas"
+);
 
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
@@ -156,7 +158,10 @@ pub struct MinReadySeconds {
   pub seconds: i32,
 }
 
-finding::impl_findings!(MinReadySeconds, "✅ - All relevant Kubernetes workloads minReadySeconds set to more than 0");
+finding::impl_findings!(
+  MinReadySeconds,
+  "✅ - All relevant Kubernetes workloads minReadySeconds set to more than 0"
+);
 
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
@@ -170,7 +175,10 @@ pub struct PodTopologyDistribution {
   pub topology_spread_constraints: bool,
 }
 
-finding::impl_findings!(PodTopologyDistribution, "✅ - All relevant Kubernetes workloads have either podAntiAffinity or topologySpreadConstraints set");
+finding::impl_findings!(
+  PodTopologyDistribution,
+  "✅ - All relevant Kubernetes workloads have either podAntiAffinity or topologySpreadConstraints set"
+);
 
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
@@ -184,7 +192,10 @@ pub struct Probe {
   pub readiness_probe: bool,
 }
 
-finding::impl_findings!(Probe, "✅ - All relevant Kubernetes workloads have a readiness probe configured");
+finding::impl_findings!(
+  Probe,
+  "✅ - All relevant Kubernetes workloads have a readiness probe configured"
+);
 
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
@@ -198,7 +209,10 @@ pub struct TerminationGracePeriod {
   pub termination_grace_period: i64,
 }
 
-finding::impl_findings!(TerminationGracePeriod, "✅ - No StatefulSet workloads have a terminationGracePeriodSeconds set to more than 0");
+finding::impl_findings!(
+  TerminationGracePeriod,
+  "✅ - No StatefulSet workloads have a terminationGracePeriodSeconds set to more than 0"
+);
 
 #[derive(Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
@@ -212,7 +226,10 @@ pub struct DockerSocket {
   pub docker_socket: bool,
 }
 
-finding::impl_findings!(DockerSocket, "✅ - No relevant Kubernetes workloads are found to be utilizing the Docker socket");
+finding::impl_findings!(
+  DockerSocket,
+  "✅ - No relevant Kubernetes workloads are found to be utilizing the Docker socket"
+);
 
 #[derive(Clone, Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
@@ -242,10 +259,16 @@ pub fn kube_proxy_version_skew(
     }
   };
 
-  let ptmpl = kube_proxy.spec.template.as_ref().context("kube-proxy has no pod template")?;
+  let ptmpl = kube_proxy
+    .spec
+    .template
+    .as_ref()
+    .context("kube-proxy has no pod template")?;
   let pspec = ptmpl.spec.as_ref().context("kube-proxy pod template has no spec")?;
   let first_container = pspec.containers.first().context("kube-proxy has no containers")?;
-  let image_tag = first_container.image.as_deref()
+  let image_tag = first_container
+    .image
+    .as_deref()
     .and_then(|img| img.split(':').nth(1))
     .context("kube-proxy container image has no version tag")?;
   let kproxy_minor_version = version::parse_minor(image_tag)?;
@@ -270,7 +293,10 @@ pub fn kube_proxy_version_skew(
   }])
 }
 
-finding::impl_findings!(KubeProxyVersionSkew, "✅ - `kube-proxy` version is aligned with the node/`kubelet` versions in use");
+finding::impl_findings!(
+  KubeProxyVersionSkew,
+  "✅ - `kube-proxy` version is aligned with the node/`kubelet` versions in use"
+);
 
 #[derive(Clone, Debug, Serialize, Deserialize, Tabled)]
 #[tabled(rename_all = "UpperCase")]
@@ -281,14 +307,14 @@ pub struct KubeProxyIpvsMode {
   pub current_mode: String,
 }
 
-finding::impl_findings!(KubeProxyIpvsMode, "✅ - `kube-proxy` is not using the deprecated IPVS mode");
+finding::impl_findings!(
+  KubeProxyIpvsMode,
+  "✅ - `kube-proxy` is not using the deprecated IPVS mode"
+);
 
 /// Check if kube-proxy is configured with IPVS mode, which is deprecated in 1.35 and
 /// removed in 1.36
-pub fn kube_proxy_ipvs_mode(
-  configmap: Option<&ConfigMap>,
-  target_minor: i32,
-) -> Result<Vec<KubeProxyIpvsMode>> {
+pub fn kube_proxy_ipvs_mode(configmap: Option<&ConfigMap>, target_minor: i32) -> Result<Vec<KubeProxyIpvsMode>> {
   if target_minor < 35 {
     return Ok(vec![]);
   }
@@ -308,12 +334,10 @@ pub fn kube_proxy_ipvs_mode(
     None => return Ok(vec![]),
   };
 
-  let config: serde_yaml::Value = serde_yaml::from_str(config_str)
-    .context("Failed to parse kube-proxy-config ConfigMap as YAML")?;
+  let config: serde_yaml::Value =
+    serde_yaml::from_str(config_str).context("Failed to parse kube-proxy-config ConfigMap as YAML")?;
 
-  let mode = config.get("mode")
-    .and_then(|v| v.as_str())
-    .unwrap_or("");
+  let mode = config.get("mode").and_then(|v| v.as_str()).unwrap_or("");
 
   if mode == "ipvs" {
     let remediation = if target_minor >= 36 {
@@ -341,7 +365,10 @@ pub struct IngressNginxRetirement {
   pub image: String,
 }
 
-finding::impl_findings!(IngressNginxRetirement, "✅ - No Ingress NGINX controller images detected that require migration");
+finding::impl_findings!(
+  IngressNginxRetirement,
+  "✅ - No Ingress NGINX controller images detected that require migration"
+);
 
 /// Check for the retired Kubernetes community Ingress NGINX controller images
 /// which are no longer maintained as of 1.35+
@@ -357,7 +384,10 @@ pub fn ingress_nginx_retirement(
 
   for resource in resources {
     // Only check Deployments and DaemonSets
-    if !matches!(resource.metadata.kind, resources::Kind::Deployment | resources::Kind::DaemonSet) {
+    if !matches!(
+      resource.metadata.kind,
+      resources::Kind::Deployment | resources::Kind::DaemonSet
+    ) {
       continue;
     }
 
@@ -410,7 +440,10 @@ pub struct MissingPdb {
   pub has_max_unavailable: bool,
 }
 
-finding::impl_findings!(MissingPdb, "✅ - All relevant Kubernetes workloads have a PodDisruptionBudget configured");
+finding::impl_findings!(
+  MissingPdb,
+  "✅ - All relevant Kubernetes workloads have a PodDisruptionBudget configured"
+);
 
 /// K8S004 - Check if workloads have an associated PodDisruptionBudget with
 /// at least one of minAvailable or maxUnavailable configured
@@ -522,9 +555,11 @@ pub trait K8sFindings {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
   use std::collections::BTreeMap;
+
   use k8s_openapi::api::core::v1::{Container, PodSpec, PodTemplateSpec};
+
+  use super::*;
 
   // ---------------------------------------------------------------------------
   // Helpers
@@ -681,11 +716,11 @@ mod tests {
   #[test]
   fn version_skew_multiple_mixed_nodes() {
     let nodes = vec![
-      make_node("same", 30),      // skew 0 -> skipped
-      make_node("ahead", 31),     // ahead -> skipped
-      make_node("behind-1", 29),  // skew 1 -> Recommended
-      make_node("behind-3", 27),  // skew 3 -> Required
-      make_node("behind-4", 26),  // skew 4 -> Required
+      make_node("same", 30),     // skew 0 -> skipped
+      make_node("ahead", 31),    // ahead -> skipped
+      make_node("behind-1", 29), // skew 1 -> Recommended
+      make_node("behind-3", 27), // skew 3 -> Required
+      make_node("behind-4", 26), // skew 4 -> Required
     ];
     let result = version_skew(&nodes, 30);
     assert_eq!(result.len(), 3);
@@ -719,18 +754,16 @@ mod tests {
 
   #[test]
   fn kube_proxy_version_skew_no_skew() {
-    let ds = make_kube_proxy_daemonset(
-      "602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.30.0-eksbuild.3",
-    );
+    let ds =
+      make_kube_proxy_daemonset("602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.30.0-eksbuild.3");
     let result = kube_proxy_version_skew(&[ds], 30).unwrap();
     assert!(result.is_empty(), "same version should produce no findings");
   }
 
   #[test]
   fn kube_proxy_version_skew_1_recommended() {
-    let ds = make_kube_proxy_daemonset(
-      "602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.29.0-eksbuild.3",
-    );
+    let ds =
+      make_kube_proxy_daemonset("602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.29.0-eksbuild.3");
     let result = kube_proxy_version_skew(&[ds], 30).unwrap();
     assert_eq!(result.len(), 1);
     assert!(matches!(result[0].finding.remediation, Remediation::Recommended));
@@ -739,9 +772,8 @@ mod tests {
 
   #[test]
   fn kube_proxy_version_skew_3_required() {
-    let ds = make_kube_proxy_daemonset(
-      "602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.0-eksbuild.3",
-    );
+    let ds =
+      make_kube_proxy_daemonset("602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.0-eksbuild.3");
     let result = kube_proxy_version_skew(&[ds], 30).unwrap();
     assert_eq!(result.len(), 1);
     assert!(matches!(result[0].finding.remediation, Remediation::Required));
@@ -750,11 +782,13 @@ mod tests {
 
   #[test]
   fn kube_proxy_version_skew_node_ahead() {
-    let ds = make_kube_proxy_daemonset(
-      "602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.31.0-eksbuild.3",
-    );
+    let ds =
+      make_kube_proxy_daemonset("602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.31.0-eksbuild.3");
     let result = kube_proxy_version_skew(&[ds], 30).unwrap();
-    assert!(result.is_empty(), "kube-proxy ahead of control plane should return empty");
+    assert!(
+      result.is_empty(),
+      "kube-proxy ahead of control plane should return empty"
+    );
   }
 
   // ===========================================================================
@@ -870,11 +904,7 @@ mod tests {
       "k8s.gcr.io/ingress-nginx/controller:v1.5.1",
     );
     // A non-matching resource that should be ignored
-    let deploy3 = make_deployment_with_image(
-      "my-app",
-      "default",
-      "my-registry.io/my-app:v2.0",
-    );
+    let deploy3 = make_deployment_with_image("my-app", "default", "my-registry.io/my-app:v2.0");
     let result = ingress_nginx_retirement(&[deploy1, deploy2, deploy3], 35).unwrap();
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].resource.name, "ingress-nginx-controller");
@@ -885,9 +915,9 @@ mod tests {
   // pod_disruption_budgets
   // ===========================================================================
 
+  use k8s_openapi::apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString};
+
   use crate::k8s::resources::StdPdb;
-  use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
-  use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 
   fn make_pdb_fixture(
     name: &str,

--- a/eksup/src/k8s/findings.rs
+++ b/eksup/src/k8s/findings.rs
@@ -48,7 +48,10 @@ pub async fn get_kubernetes_findings(
     .filter_map(|s| match s.docker_socket() {
       Ok(finding) => finding,
       Err(e) => {
-        warn!("Failed to check docker socket for {}/{}: {e}", s.metadata.namespace, s.metadata.name);
+        warn!(
+          "Failed to check docker socket for {}/{}: {e}",
+          s.metadata.namespace, s.metadata.name
+        );
         None
       }
     })

--- a/eksup/src/k8s/resources.rs
+++ b/eksup/src/k8s/resources.rs
@@ -1,19 +1,28 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
-use k8s_openapi::api::{
-  apps, batch,
-  core::{self, v1::PodTemplateSpec},
-  policy::v1::PodDisruptionBudget,
+use k8s_openapi::{
+  api::{
+    apps, batch,
+    core::{self, v1::PodTemplateSpec},
+    policy::v1::PodDisruptionBudget,
+  },
+  apimachinery::pkg::util::intstr::IntOrString,
 };
-use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
-use kube::{Client, CustomResource, api::{Api, ListParams}};
+use kube::{
+  Client, CustomResource,
+  api::{Api, ListParams},
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tabled::Tabled;
 use tracing::warn;
 
-use crate::{finding::{Code, Finding, Remediation}, k8s::checks, version};
+use crate::{
+  finding::{Code, Finding, Remediation},
+  k8s::checks,
+  version,
+};
 
 /// Custom resource definition for ENIConfig as specified in the AWS VPC CNI
 ///
@@ -152,7 +161,9 @@ pub async fn get_eniconfigs(client: &Client) -> Result<Vec<ENIConfig>> {
 
 async fn get_deployments(client: &Client) -> Result<Vec<StdResource>> {
   let api: Api<apps::v1::Deployment> = Api::all(client.to_owned());
-  let deployment_list = list_all(&api, LIST_PAGE_SIZE).await.context("Failed to list Deployments")?;
+  let deployment_list = list_all(&api, LIST_PAGE_SIZE)
+    .await
+    .context("Failed to list Deployments")?;
 
   let deployments = deployment_list
     .iter()
@@ -188,7 +199,9 @@ async fn get_deployments(client: &Client) -> Result<Vec<StdResource>> {
 
 async fn get_replicasets(client: &Client) -> Result<Vec<StdResource>> {
   let api: Api<apps::v1::ReplicaSet> = Api::all(client.to_owned());
-  let replicaset_list = list_all(&api, LIST_PAGE_SIZE).await.context("Failed to list ReplicaSets")?;
+  let replicaset_list = list_all(&api, LIST_PAGE_SIZE)
+    .await
+    .context("Failed to list ReplicaSets")?;
 
   let replicasets = replicaset_list
     .iter()
@@ -227,7 +240,9 @@ async fn get_replicasets(client: &Client) -> Result<Vec<StdResource>> {
 
 async fn get_statefulsets(client: &Client) -> Result<Vec<StdResource>> {
   let api: Api<apps::v1::StatefulSet> = Api::all(client.to_owned());
-  let statefulset_list = list_all(&api, LIST_PAGE_SIZE).await.context("Failed to list StatefulSets")?;
+  let statefulset_list = list_all(&api, LIST_PAGE_SIZE)
+    .await
+    .context("Failed to list StatefulSets")?;
 
   let statefulsets = statefulset_list
     .iter()
@@ -263,7 +278,9 @@ async fn get_statefulsets(client: &Client) -> Result<Vec<StdResource>> {
 
 async fn get_daemonsets(client: &Client) -> Result<Vec<StdResource>> {
   let api: Api<apps::v1::DaemonSet> = Api::all(client.to_owned());
-  let daemonset_list = list_all(&api, LIST_PAGE_SIZE).await.context("Failed to list DaemonSets")?;
+  let daemonset_list = list_all(&api, LIST_PAGE_SIZE)
+    .await
+    .context("Failed to list DaemonSets")?;
 
   let daemonsets = daemonset_list
     .iter()
@@ -338,7 +355,9 @@ async fn get_jobs(client: &Client) -> Result<Vec<StdResource>> {
 
 async fn get_cronjobs(client: &Client) -> Result<Vec<StdResource>> {
   let api: Api<batch::v1::CronJob> = Api::all(client.to_owned());
-  let cronjob_list = list_all(&api, LIST_PAGE_SIZE).await.context("Failed to list CronJobs")?;
+  let cronjob_list = list_all(&api, LIST_PAGE_SIZE)
+    .await
+    .context("Failed to list CronJobs")?;
 
   let cronjobs = cronjob_list
     .iter()
@@ -572,8 +591,7 @@ pub async fn get_resources(client: &Client) -> Result<Vec<StdResource>> {
   )?;
 
   let mut resources = Vec::with_capacity(
-    cronjobs.len() + daemonsets.len() + deployments.len()
-    + jobs.len() + replicasets.len() + statefulsets.len(),
+    cronjobs.len() + daemonsets.len() + deployments.len() + jobs.len() + replicasets.len() + statefulsets.len(),
   );
   resources.extend(cronjobs);
   resources.extend(daemonsets);
@@ -597,7 +615,9 @@ pub struct StdPdb {
 
 pub async fn get_pod_disruption_budgets(client: &Client) -> Result<Vec<StdPdb>> {
   let api: Api<PodDisruptionBudget> = Api::all(client.to_owned());
-  let pdb_list = list_all(&api, LIST_PAGE_SIZE).await.context("Failed to list PodDisruptionBudgets")?;
+  let pdb_list = list_all(&api, LIST_PAGE_SIZE)
+    .await
+    .context("Failed to list PodDisruptionBudgets")?;
 
   Ok(
     pdb_list
@@ -609,7 +629,13 @@ pub async fn get_pod_disruption_budgets(client: &Client) -> Result<Vec<StdPdb>> 
           Some(spec) => (spec.selector, spec.min_available, spec.max_unavailable),
           None => (None, None, None),
         };
-        StdPdb { name, namespace, selector, min_available, max_unavailable }
+        StdPdb {
+          name,
+          namespace,
+          selector,
+          min_available,
+          max_unavailable,
+        }
       })
       .collect(),
   )
@@ -648,10 +674,8 @@ pub fn selector_matches(
             return false;
           }
         }
-        "DoesNotExist" => {
-          if label_value.is_some() {
-            return false;
-          }
+        "DoesNotExist" if label_value.is_some() => {
+          return false;
         }
         _ => {}
       }
@@ -662,14 +686,16 @@ pub fn selector_matches(
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use crate::finding::Remediation;
-  use crate::k8s::checks::K8sFindings;
-  use k8s_openapi::api::core::v1::{
-    Affinity, Container, HTTPGetAction, PodAffinityTerm, PodAntiAffinity, PodSpec, PodTemplateSpec,
-    Probe as K8sProbe, TopologySpreadConstraint, VolumeMount,
+  use k8s_openapi::{
+    api::core::v1::{
+      Affinity, Container, HTTPGetAction, PodAffinityTerm, PodAntiAffinity, PodSpec, PodTemplateSpec,
+      Probe as K8sProbe, TopologySpreadConstraint, VolumeMount,
+    },
+    apimachinery::pkg::apis::meta::v1::LabelSelector,
   };
-  use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+
+  use super::*;
+  use crate::{finding::Remediation, k8s::checks::K8sFindings};
 
   fn make_resource(
     kind: Kind,
@@ -772,7 +798,10 @@ mod tests {
 
   #[test]
   fn min_replicas_below_threshold() {
-    let cfg = crate::config::K8s002Config { min_replicas: 3, ..Default::default() };
+    let cfg = crate::config::K8s002Config {
+      min_replicas: 3,
+      ..Default::default()
+    };
     let r = make_resource(Kind::Deployment, "web", Some(2), None, Some(basic_template()));
     let result = r.min_replicas(&cfg);
     assert!(result.is_some());
@@ -911,13 +940,7 @@ mod tests {
 
   #[test]
   fn topology_spread() {
-    let r = make_resource(
-      Kind::Deployment,
-      "web",
-      Some(3),
-      None,
-      Some(template_with_spread()),
-    );
+    let r = make_resource(Kind::Deployment, "web", Some(3), None, Some(template_with_spread()));
     assert!(r.pod_topology_distribution().is_none());
   }
 
@@ -1165,11 +1188,13 @@ mod tests {
       minor_version: 28,
     };
     assert_eq!(node.name, "ip-10-0-1-42");
-    assert!(node
-      .labels
-      .as_ref()
-      .unwrap()
-      .contains_key("node.kubernetes.io/instance-type"));
+    assert!(
+      node
+        .labels
+        .as_ref()
+        .unwrap()
+        .contains_key("node.kubernetes.io/instance-type")
+    );
     assert_eq!(node.kubelet_version, "v1.28.3");
   }
 

--- a/eksup/src/k8s/resources.rs
+++ b/eksup/src/k8s/resources.rs
@@ -659,20 +659,14 @@ pub fn selector_matches(
       let label_value = labels.get(&expr.key);
       let values = expr.values.as_deref().unwrap_or_default();
       match expr.operator.as_str() {
-        "In" => {
-          if !label_value.is_some_and(|v| values.contains(v)) {
-            return false;
-          }
+        "In" if !label_value.is_some_and(|v| values.contains(v)) => {
+          return false;
         }
-        "NotIn" => {
-          if label_value.is_some_and(|v| values.contains(v)) {
-            return false;
-          }
+        "NotIn" if label_value.is_some_and(|v| values.contains(v)) => {
+          return false;
         }
-        "Exists" => {
-          if label_value.is_none() {
-            return false;
-          }
+        "Exists" if label_value.is_none() => {
+          return false;
         }
         "DoesNotExist" if label_value.is_some() => {
           return false;

--- a/eksup/src/lib.rs
+++ b/eksup/src/lib.rs
@@ -11,7 +11,6 @@ pub mod version;
 use std::{env, str};
 
 use anyhow::{Context, Result};
-use clients::AwsClients;
 use aws_config::default_provider::{credentials::DefaultCredentialsChain, region::DefaultRegionChain};
 use aws_sdk_eks::config::Region;
 use clap::{
@@ -19,6 +18,7 @@ use clap::{
   builder::styling::{AnsiColor, Color, Style, Styles},
 };
 use clap_verbosity_flag::Verbosity;
+use clients::AwsClients;
 use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
 use serde::{Deserialize, Serialize};
 
@@ -30,16 +30,8 @@ fn get_styles() -> Styles {
         .underline()
         .fg_color(Some(Color::Ansi(AnsiColor::Green))),
     )
-    .literal(
-      Style::new()
-        .bold()
-        .fg_color(Some(Color::Ansi(AnsiColor::BrightCyan))),
-    )
-    .usage(
-      Style::new()
-        .bold()
-        .fg_color(Some(Color::Ansi(AnsiColor::Green))),
-    )
+    .literal(Style::new().bold().fg_color(Some(Color::Ansi(AnsiColor::BrightCyan))))
+    .usage(Style::new().bold().fg_color(Some(Color::Ansi(AnsiColor::Green))))
     .placeholder(
       Style::new()
         .bold()
@@ -292,9 +284,10 @@ pub async fn create(args: Create) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
   use clap::CommandFactory;
-  use clap_complete::{generate, Shell};
+  use clap_complete::{Shell, generate};
+
+  use super::*;
 
   #[test]
   fn completion_generates_for_all_shells() {

--- a/eksup/src/lib.rs
+++ b/eksup/src/lib.rs
@@ -66,6 +66,14 @@ pub enum Commands {
   Analyze(Analysis),
   #[command(arg_required_else_help = true)]
   Create(Create),
+
+  /// Generate shell completion script for the given shell
+  #[command(arg_required_else_help = true)]
+  Completion {
+    /// The shell to generate completions for
+    #[arg(value_enum)]
+    shell: clap_complete::Shell,
+  },
 }
 
 /// Analyze an Amazon EKS cluster for potential upgrade issues
@@ -277,4 +285,21 @@ pub async fn create(args: Create) -> Result<()> {
   }
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use clap::CommandFactory;
+  use clap_complete::{generate, Shell};
+
+  #[test]
+  fn completion_generates_for_all_shells() {
+    let mut cmd = Cli::command();
+    for shell in [Shell::Bash, Shell::Elvish, Shell::Fish, Shell::PowerShell, Shell::Zsh] {
+      let mut buf = Vec::new();
+      generate(shell, &mut cmd, "eksup", &mut buf);
+      assert!(!buf.is_empty(), "{shell:?} produced empty completion output");
+    }
+  }
 }

--- a/eksup/src/lib.rs
+++ b/eksup/src/lib.rs
@@ -74,6 +74,9 @@ pub enum Commands {
     #[arg(value_enum)]
     shell: clap_complete::Shell,
   },
+
+  /// Generate the man page for eksup
+  Man,
 }
 
 /// Analyze an Amazon EKS cluster for potential upgrade issues
@@ -301,5 +304,12 @@ mod tests {
       generate(shell, &mut cmd, "eksup", &mut buf);
       assert!(!buf.is_empty(), "{shell:?} produced empty completion output");
     }
+  }
+
+  #[test]
+  fn man_renders() {
+    let mut buf = Vec::new();
+    clap_mangen::Man::new(Cli::command()).render(&mut buf).unwrap();
+    assert!(!buf.is_empty(), "man page rendered empty");
   }
 }

--- a/eksup/src/main.rs
+++ b/eksup/src/main.rs
@@ -3,7 +3,7 @@
 //! `eksup` is a CLI to aid in upgrading Amazon EKS clusters
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use eksup::{Cli, Commands, analyze, create};
 use tracing_subscriber::FmtSubscriber;
 
@@ -22,6 +22,10 @@ async fn main() -> Result<()> {
   match cli.commands {
     Commands::Analyze(args) => analyze(args).await?,
     Commands::Create(args) => create(args).await?,
+    Commands::Completion { shell } => {
+      let mut cmd = Cli::command();
+      clap_complete::generate(shell, &mut cmd, "eksup", &mut std::io::stdout());
+    }
   }
 
   Ok(())

--- a/eksup/src/main.rs
+++ b/eksup/src/main.rs
@@ -26,6 +26,9 @@ async fn main() -> Result<()> {
       let mut cmd = Cli::command();
       clap_complete::generate(shell, &mut cmd, "eksup", &mut std::io::stdout());
     }
+    Commands::Man => {
+      clap_mangen::Man::new(Cli::command()).render(&mut std::io::stdout())?;
+    }
   }
 
   Ok(())

--- a/eksup/src/playbook.rs
+++ b/eksup/src/playbook.rs
@@ -116,7 +116,8 @@ pub fn render(region: &str, cluster: &Cluster, analysis: analysis::Results, targ
   let target_version = version::format_version(target_minor);
 
   let release_data = get_release_data()?;
-  let release = release_data.get(&target_version)
+  let release = release_data
+    .get(&target_version)
     .context(format!("No release data found for version {target_version}"))?;
 
   let cluster_findings = analysis.cluster;
@@ -136,9 +137,7 @@ pub fn render(region: &str, cluster: &Cluster, analysis: analysis::Results, targ
     eks_managed_nodegroup_update: data_plane_findings
       .eks_managed_nodegroup_update
       .to_markdown_table("\t")?,
-    al2_ami_deprecation: data_plane_findings
-      .al2_ami_deprecation
-      .to_markdown_table("\t")?,
+    al2_ami_deprecation: data_plane_findings.al2_ami_deprecation.to_markdown_table("\t")?,
   };
   let eks_managed_nodegroup_template = handlebars.render("eks-managed-nodegroup.md", &eks_mng_tmpl_data)?;
 
@@ -150,8 +149,7 @@ pub fn render(region: &str, cluster: &Cluster, analysis: analysis::Results, targ
       .self_managed_nodegroup_update
       .to_markdown_table("\t")?,
   };
-  let self_managed_nodegroup_template =
-    handlebars.render("self-managed-nodegroup.md", &self_mng_tmpl_data)?;
+  let self_managed_nodegroup_template = handlebars.render("self-managed-nodegroup.md", &self_mng_tmpl_data)?;
 
   let fargate_tmpl_data = FargateProfileTemplateData {
     region: region.to_owned(),
@@ -204,7 +202,13 @@ pub fn render(region: &str, cluster: &Cluster, analysis: analysis::Results, targ
   Ok(rendered)
 }
 
-pub(crate) fn create(args: Playbook, region: String, cluster: &Cluster, analysis: analysis::Results, target_minor: i32) -> Result<()> {
+pub(crate) fn create(
+  args: Playbook,
+  region: String,
+  cluster: &Cluster,
+  analysis: analysis::Results,
+  target_minor: i32,
+) -> Result<()> {
   let cluster_name = cluster.name().context("Cluster name missing")?;
   let target_version = version::format_version(target_minor);
   let default_playbook_name = format!("{cluster_name}_v{target_version}_upgrade.md");

--- a/eksup/src/version.rs
+++ b/eksup/src/version.rs
@@ -67,8 +67,9 @@ pub fn validate_target_version(target: &str, cluster_version: &str) -> Result<i3
   let target_minor = if target_str.contains('.') {
     parse_minor(target_str)?
   } else {
-    target_str.parse::<i32>()
-      .context(format!("Invalid target version '{target}', expected format like '1.34' or '34'"))?
+    target_str.parse::<i32>().context(format!(
+      "Invalid target version '{target}', expected format like '1.34' or '34'"
+    ))?
   };
 
   let current_minor = parse_minor(cluster_version)?;
@@ -97,7 +98,8 @@ pub fn validate_target_version(target: &str, cluster_version: &str) -> Result<i3
 /// Or the format of v1.22.7 returns 22
 pub fn parse_minor(version: &str) -> Result<i32> {
   let parts: Vec<&str> = version.split('.').collect();
-  let minor_str = parts.get(1)
+  let minor_str = parts
+    .get(1)
     .context(format!("Invalid version format '{version}', expected 'X.Y[.Z]'"))?;
   let minor = minor_str.parse::<i32>()?;
 
@@ -153,7 +155,10 @@ mod tests {
     let result = get_target_version("1.29");
     assert!(result.is_err(), "should error when below MINIMUM");
     let msg = result.unwrap_err().to_string();
-    assert!(msg.contains("below the minimum supported version"), "error message: {msg}");
+    assert!(
+      msg.contains("below the minimum supported version"),
+      "error message: {msg}"
+    );
   }
 
   #[test]

--- a/eksup/tests/common/fixtures.rs
+++ b/eksup/tests/common/fixtures.rs
@@ -1,13 +1,15 @@
+#![allow(dead_code)]
+
 use std::collections::BTreeMap;
 
 use aws_sdk_eks::types::{Cluster, ClusterHealth, VpcConfigResponse};
+use eksup::{
+  eks::resources::{AddonVersion, ClusterInsight, VpcSubnet},
+  k8s::resources::{Kind, Node, StdMetadata, StdPdb, StdResource, StdSpec},
+};
 use k8s_openapi::api::core::v1::{Container, PodSpec, PodTemplateSpec};
 
-use eksup::eks::resources::{AddonVersion, ClusterInsight, VpcSubnet};
-use eksup::k8s::resources::{Kind, Node, StdMetadata, StdPdb, StdResource, StdSpec};
-
-use super::mock_aws::MockAwsClients;
-use super::mock_k8s::MockK8sClients;
+use super::{mock_aws::MockAwsClients, mock_k8s::MockK8sClients};
 
 /// Builds a healthy cluster at version 1.30 with sufficient IPs
 pub fn healthy_aws() -> MockAwsClients {
@@ -24,8 +26,16 @@ pub fn healthy_aws() -> MockAwsClients {
       )
       .build(),
     subnet_ips: vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 100, availability_zone_id: "use1-az1".into() },
-      VpcSubnet { id: "subnet-2".into(), available_ips: 100, availability_zone_id: "use1-az2".into() },
+      VpcSubnet {
+        id: "subnet-1".into(),
+        available_ips: 100,
+        availability_zone_id: "use1-az1".into(),
+      },
+      VpcSubnet {
+        id: "subnet-2".into(),
+        available_ips: 100,
+        availability_zone_id: "use1-az2".into(),
+      },
     ],
     ..Default::default()
   }
@@ -81,8 +91,7 @@ pub fn make_pdb(
   has_min_available: bool,
   has_max_unavailable: bool,
 ) -> StdPdb {
-  use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
-  use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+  use k8s_openapi::apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString};
   StdPdb {
     name: name.into(),
     namespace: namespace.into(),
@@ -90,8 +99,16 @@ pub fn make_pdb(
       match_labels: Some(match_labels),
       ..Default::default()
     }),
-    min_available: if has_min_available { Some(IntOrString::Int(1)) } else { None },
-    max_unavailable: if has_max_unavailable { Some(IntOrString::Int(1)) } else { None },
+    min_available: if has_min_available {
+      Some(IntOrString::Int(1))
+    } else {
+      None
+    },
+    max_unavailable: if has_max_unavailable {
+      Some(IntOrString::Int(1))
+    } else {
+      None
+    },
   }
 }
 

--- a/eksup/tests/common/mock_aws.rs
+++ b/eksup/tests/common/mock_aws.rs
@@ -1,11 +1,14 @@
+#![allow(dead_code)]
+
 use std::collections::HashMap;
 
 use anyhow::{Result, bail};
 use aws_sdk_autoscaling::types::AutoScalingGroup;
 use aws_sdk_eks::types::{Addon, Cluster, FargateProfile, Nodegroup};
-
-use eksup::clients::AwsClients;
-use eksup::eks::resources::{AddonVersion, ClusterInsight, LaunchTemplate, VpcSubnet};
+use eksup::{
+  clients::AwsClients,
+  eks::resources::{AddonVersion, ClusterInsight, LaunchTemplate, VpcSubnet},
+};
 
 /// Mock AWS client for testing. All fields default to "healthy" empty data.
 /// Override specific fields to simulate different cluster states.
@@ -28,10 +31,7 @@ pub struct MockAwsClients {
 impl Default for MockAwsClients {
   fn default() -> Self {
     Self {
-      cluster: Cluster::builder()
-        .name("test-cluster")
-        .version("1.30")
-        .build(),
+      cluster: Cluster::builder().name("test-cluster").version("1.30").build(),
       subnet_ips: vec![],
       addons: vec![],
       addon_versions: HashMap::new(),
@@ -62,7 +62,10 @@ impl AwsClients for MockAwsClients {
 
   async fn get_addon_versions(&self, name: &str, kubernetes_version: &str) -> Result<AddonVersion> {
     let key = (name.to_string(), kubernetes_version.to_string());
-    self.addon_versions.get(&key).cloned()
+    self
+      .addon_versions
+      .get(&key)
+      .cloned()
       .ok_or_else(|| anyhow::anyhow!("No mock addon version for {name} @ {kubernetes_version}"))
   }
 
@@ -79,13 +82,19 @@ impl AwsClients for MockAwsClients {
   }
 
   async fn get_launch_template(&self, id: &str) -> Result<LaunchTemplate> {
-    self.launch_templates.get(id).cloned()
+    self
+      .launch_templates
+      .get(id)
+      .cloned()
       .ok_or_else(|| anyhow::anyhow!("No mock launch template for id {id}"))
   }
 
   async fn get_service_quota_usage(&self, service_code: &str, quota_code: &str) -> Result<(String, f64, String)> {
     let key = (service_code.to_string(), quota_code.to_string());
-    self.service_quotas.get(&key).cloned()
+    self
+      .service_quotas
+      .get(&key)
+      .cloned()
       .ok_or_else(|| anyhow::anyhow!("No mock quota for {service_code}/{quota_code}"))
   }
 
@@ -106,16 +115,40 @@ impl AwsClients for MockAwsClients {
 pub struct MockAwsClientsError;
 
 impl AwsClients for MockAwsClientsError {
-  async fn get_cluster(&self, _name: &str) -> Result<Cluster> { bail!("mock AWS error") }
-  async fn get_subnet_ips(&self, _subnet_ids: Vec<String>) -> Result<Vec<VpcSubnet>> { bail!("mock AWS error") }
-  async fn get_addons(&self, _cluster_name: &str) -> Result<Vec<Addon>> { bail!("mock AWS error") }
-  async fn get_addon_versions(&self, _name: &str, _kubernetes_version: &str) -> Result<AddonVersion> { bail!("mock AWS error") }
-  async fn get_eks_managed_nodegroups(&self, _cluster_name: &str) -> Result<Vec<Nodegroup>> { bail!("mock AWS error") }
-  async fn get_self_managed_nodegroups(&self, _cluster_name: &str) -> Result<Vec<AutoScalingGroup>> { bail!("mock AWS error") }
-  async fn get_fargate_profiles(&self, _cluster_name: &str) -> Result<Vec<FargateProfile>> { bail!("mock AWS error") }
-  async fn get_launch_template(&self, _id: &str) -> Result<LaunchTemplate> { bail!("mock AWS error") }
-  async fn get_service_quota_usage(&self, _: &str, _: &str) -> Result<(String, f64, String)> { bail!("mock AWS error") }
-  async fn get_ec2_on_demand_vcpu_count(&self) -> Result<f64> { bail!("mock AWS error") }
-  async fn get_ebs_volume_storage(&self, _: &str) -> Result<f64> { bail!("mock AWS error") }
-  async fn get_cluster_insights(&self, _cluster_name: &str) -> Result<Vec<ClusterInsight>> { bail!("mock AWS error") }
+  async fn get_cluster(&self, _name: &str) -> Result<Cluster> {
+    bail!("mock AWS error")
+  }
+  async fn get_subnet_ips(&self, _subnet_ids: Vec<String>) -> Result<Vec<VpcSubnet>> {
+    bail!("mock AWS error")
+  }
+  async fn get_addons(&self, _cluster_name: &str) -> Result<Vec<Addon>> {
+    bail!("mock AWS error")
+  }
+  async fn get_addon_versions(&self, _name: &str, _kubernetes_version: &str) -> Result<AddonVersion> {
+    bail!("mock AWS error")
+  }
+  async fn get_eks_managed_nodegroups(&self, _cluster_name: &str) -> Result<Vec<Nodegroup>> {
+    bail!("mock AWS error")
+  }
+  async fn get_self_managed_nodegroups(&self, _cluster_name: &str) -> Result<Vec<AutoScalingGroup>> {
+    bail!("mock AWS error")
+  }
+  async fn get_fargate_profiles(&self, _cluster_name: &str) -> Result<Vec<FargateProfile>> {
+    bail!("mock AWS error")
+  }
+  async fn get_launch_template(&self, _id: &str) -> Result<LaunchTemplate> {
+    bail!("mock AWS error")
+  }
+  async fn get_service_quota_usage(&self, _: &str, _: &str) -> Result<(String, f64, String)> {
+    bail!("mock AWS error")
+  }
+  async fn get_ec2_on_demand_vcpu_count(&self) -> Result<f64> {
+    bail!("mock AWS error")
+  }
+  async fn get_ebs_volume_storage(&self, _: &str) -> Result<f64> {
+    bail!("mock AWS error")
+  }
+  async fn get_cluster_insights(&self, _cluster_name: &str) -> Result<Vec<ClusterInsight>> {
+    bail!("mock AWS error")
+  }
 }

--- a/eksup/tests/common/mock_k8s.rs
+++ b/eksup/tests/common/mock_k8s.rs
@@ -1,8 +1,11 @@
-use anyhow::{Result, bail};
-use k8s_openapi::api::core::v1::ConfigMap;
+#![allow(dead_code)]
 
-use eksup::clients::K8sClients;
-use eksup::k8s::resources::{ENIConfig, Node, StdPdb, StdResource};
+use anyhow::{Result, bail};
+use eksup::{
+  clients::K8sClients,
+  k8s::resources::{ENIConfig, Node, StdPdb, StdResource},
+};
+use k8s_openapi::api::core::v1::ConfigMap;
 
 /// Mock K8s client for testing
 #[derive(Clone, Default)]
@@ -40,9 +43,19 @@ impl K8sClients for MockK8sClients {
 pub struct MockK8sClientsError;
 
 impl K8sClients for MockK8sClientsError {
-  async fn get_nodes(&self) -> Result<Vec<Node>> { bail!("mock K8s error") }
-  async fn get_configmap(&self, _namespace: &str, _name: &str) -> Result<Option<ConfigMap>> { bail!("mock K8s error") }
-  async fn get_eniconfigs(&self) -> Result<Vec<ENIConfig>> { bail!("mock K8s error") }
-  async fn get_resources(&self) -> Result<Vec<StdResource>> { bail!("mock K8s error") }
-  async fn get_pod_disruption_budgets(&self) -> Result<Vec<StdPdb>> { bail!("mock K8s error") }
+  async fn get_nodes(&self) -> Result<Vec<Node>> {
+    bail!("mock K8s error")
+  }
+  async fn get_configmap(&self, _namespace: &str, _name: &str) -> Result<Option<ConfigMap>> {
+    bail!("mock K8s error")
+  }
+  async fn get_eniconfigs(&self) -> Result<Vec<ENIConfig>> {
+    bail!("mock K8s error")
+  }
+  async fn get_resources(&self) -> Result<Vec<StdResource>> {
+    bail!("mock K8s error")
+  }
+  async fn get_pod_disruption_budgets(&self) -> Result<Vec<StdPdb>> {
+    bail!("mock K8s error")
+  }
 }

--- a/eksup/tests/e2e.rs
+++ b/eksup/tests/e2e.rs
@@ -2,15 +2,15 @@ mod common;
 
 use aws_sdk_eks::types::{Cluster, ClusterHealth, FargateProfile, Nodegroup, VpcConfigResponse};
 use common::{fixtures, mock_aws::MockAwsClients, mock_k8s::MockK8sClients};
-use eksup::analysis::Results;
-use eksup::config::Config;
-use eksup::eks::resources::VpcSubnet;
+use eksup::{analysis::Results, config::Config, eks::resources::VpcSubnet};
 
 /// Helper: run analysis and return Results (defaults to n+1 target)
 async fn run_analysis(aws: &MockAwsClients, k8s: &MockK8sClients) -> Results {
   let cluster_version = aws.cluster.version().unwrap();
   let target_minor = eksup::version::get_target_version(cluster_version).unwrap();
-  eksup::analysis::analyze(aws, k8s, &aws.cluster, target_minor, &Config::default()).await.unwrap()
+  eksup::analysis::analyze(aws, k8s, &aws.cluster, target_minor, &Config::default())
+    .await
+    .unwrap()
 }
 
 /// Helper: render Results as text
@@ -53,8 +53,16 @@ async fn snapshot_healthy_cluster_json() {
 async fn snapshot_insufficient_control_plane_ips_text() {
   let mut aws = fixtures::healthy_aws();
   aws.subnet_ips = vec![
-    VpcSubnet { id: "subnet-1".into(), available_ips: 3, availability_zone_id: "use1-az1".into() },
-    VpcSubnet { id: "subnet-2".into(), available_ips: 2, availability_zone_id: "use1-az2".into() },
+    VpcSubnet {
+      id: "subnet-1".into(),
+      available_ips: 3,
+      availability_zone_id: "use1-az1".into(),
+    },
+    VpcSubnet {
+      id: "subnet-2".into(),
+      available_ips: 2,
+      availability_zone_id: "use1-az2".into(),
+    },
   ];
   let k8s = fixtures::healthy_k8s();
   let results = run_analysis(&aws, &k8s).await;
@@ -104,10 +112,7 @@ async fn snapshot_workload_issues_json() {
 async fn snapshot_version_skew_text() {
   let aws = fixtures::healthy_aws();
   let k8s = MockK8sClients {
-    nodes: vec![
-      fixtures::make_node("node-1", 28),
-      fixtures::make_node("node-2", 27),
-    ],
+    nodes: vec![fixtures::make_node("node-1", 28), fixtures::make_node("node-2", 27)],
     ..Default::default()
   };
   let results = run_analysis(&aws, &k8s).await;
@@ -123,8 +128,16 @@ async fn snapshot_version_skew_text() {
 async fn snapshot_mixed_findings_text() {
   let mut aws = fixtures::healthy_aws();
   aws.subnet_ips = vec![
-    VpcSubnet { id: "subnet-1".into(), available_ips: 3, availability_zone_id: "use1-az1".into() },
-    VpcSubnet { id: "subnet-2".into(), available_ips: 100, availability_zone_id: "use1-az2".into() },
+    VpcSubnet {
+      id: "subnet-1".into(),
+      available_ips: 3,
+      availability_zone_id: "use1-az1".into(),
+    },
+    VpcSubnet {
+      id: "subnet-2".into(),
+      available_ips: 100,
+      availability_zone_id: "use1-az2".into(),
+    },
   ];
   let k8s = MockK8sClients {
     nodes: vec![fixtures::make_node("node-1", 28)],
@@ -141,8 +154,16 @@ async fn snapshot_mixed_findings_text() {
 async fn snapshot_mixed_findings_json() {
   let mut aws = fixtures::healthy_aws();
   aws.subnet_ips = vec![
-    VpcSubnet { id: "subnet-1".into(), available_ips: 3, availability_zone_id: "use1-az1".into() },
-    VpcSubnet { id: "subnet-2".into(), available_ips: 100, availability_zone_id: "use1-az2".into() },
+    VpcSubnet {
+      id: "subnet-1".into(),
+      available_ips: 3,
+      availability_zone_id: "use1-az1".into(),
+    },
+    VpcSubnet {
+      id: "subnet-2".into(),
+      available_ips: 100,
+      availability_zone_id: "use1-az2".into(),
+    },
   ];
   let k8s = MockK8sClients {
     nodes: vec![fixtures::make_node("node-1", 28)],
@@ -201,8 +222,16 @@ fn aws_at_version(version: &str) -> MockAwsClients {
       )
       .build(),
     subnet_ips: vec![
-      VpcSubnet { id: "subnet-1".into(), available_ips: 100, availability_zone_id: "use1-az1".into() },
-      VpcSubnet { id: "subnet-2".into(), available_ips: 100, availability_zone_id: "use1-az2".into() },
+      VpcSubnet {
+        id: "subnet-1".into(),
+        available_ips: 100,
+        availability_zone_id: "use1-az1".into(),
+      },
+      VpcSubnet {
+        id: "subnet-2".into(),
+        available_ips: 100,
+        availability_zone_id: "use1-az2".into(),
+      },
     ],
     ..Default::default()
   }
@@ -221,9 +250,7 @@ async fn snapshot_playbook_healthy() {
 #[tokio::test]
 async fn snapshot_playbook_eks_managed_nodegroups() {
   let mut aws = fixtures::healthy_aws();
-  aws.nodegroups = vec![
-    Nodegroup::builder().nodegroup_name("mng-1").build(),
-  ];
+  aws.nodegroups = vec![Nodegroup::builder().nodegroup_name("mng-1").build()];
   let k8s = fixtures::healthy_k8s();
   let output = render_playbook(&aws, &k8s).await;
   insta::assert_snapshot!("playbook_eks_managed_nodegroups", output);
@@ -232,9 +259,7 @@ async fn snapshot_playbook_eks_managed_nodegroups() {
 #[tokio::test]
 async fn snapshot_playbook_fargate_profiles() {
   let mut aws = fixtures::healthy_aws();
-  aws.fargate_profiles = vec![
-    FargateProfile::builder().fargate_profile_name("fp-1").build(),
-  ];
+  aws.fargate_profiles = vec![FargateProfile::builder().fargate_profile_name("fp-1").build()];
   let k8s = fixtures::healthy_k8s();
   let output = render_playbook(&aws, &k8s).await;
   insta::assert_snapshot!("playbook_fargate_profiles", output);
@@ -243,19 +268,11 @@ async fn snapshot_playbook_fargate_profiles() {
 #[tokio::test]
 async fn snapshot_playbook_mixed() {
   let mut aws = fixtures::healthy_aws();
-  aws.nodegroups = vec![
-    Nodegroup::builder().nodegroup_name("mng-1").build(),
-  ];
-  aws.fargate_profiles = vec![
-    FargateProfile::builder().fargate_profile_name("fp-1").build(),
-  ];
+  aws.nodegroups = vec![Nodegroup::builder().nodegroup_name("mng-1").build()];
+  aws.fargate_profiles = vec![FargateProfile::builder().fargate_profile_name("fp-1").build()];
   let k8s = MockK8sClients {
-    nodes: vec![
-      fixtures::make_node("node-1", 28),
-    ],
-    resources: vec![
-      fixtures::make_deployment("web", "default", 1),
-    ],
+    nodes: vec![fixtures::make_node("node-1", 28)],
+    resources: vec![fixtures::make_deployment("web", "default", 1)],
     ..Default::default()
   };
   let output = render_playbook(&aws, &k8s).await;
@@ -270,37 +287,60 @@ async fn playbook_no_data_plane_sections_when_empty() {
   let k8s = fixtures::healthy_k8s();
   let output = render_playbook(&aws, &k8s).await;
 
-  assert!(!output.contains("#### EKS Managed Nodegroup"), "EKS MNG sub-template section should be absent");
-  assert!(!output.contains("#### Self-Managed Nodegroup"), "Self-managed sub-template section should be absent");
-  assert!(!output.contains("### Fargate Node"), "Fargate sub-template section should be absent");
+  assert!(
+    !output.contains("#### EKS Managed Nodegroup"),
+    "EKS MNG sub-template section should be absent"
+  );
+  assert!(
+    !output.contains("#### Self-Managed Nodegroup"),
+    "Self-managed sub-template section should be absent"
+  );
+  assert!(
+    !output.contains("### Fargate Node"),
+    "Fargate sub-template section should be absent"
+  );
 }
 
 #[tokio::test]
 async fn playbook_eks_managed_section_present_others_absent() {
   let mut aws = fixtures::healthy_aws();
-  aws.nodegroups = vec![
-    Nodegroup::builder().nodegroup_name("mng-1").build(),
-  ];
+  aws.nodegroups = vec![Nodegroup::builder().nodegroup_name("mng-1").build()];
   let k8s = fixtures::healthy_k8s();
   let output = render_playbook(&aws, &k8s).await;
 
-  assert!(output.contains("#### EKS Managed Nodegroup"), "EKS MNG sub-template section should be present");
-  assert!(!output.contains("#### Self-Managed Nodegroup"), "Self-managed sub-template section should be absent");
-  assert!(!output.contains("### Fargate Node"), "Fargate sub-template section should be absent");
+  assert!(
+    output.contains("#### EKS Managed Nodegroup"),
+    "EKS MNG sub-template section should be present"
+  );
+  assert!(
+    !output.contains("#### Self-Managed Nodegroup"),
+    "Self-managed sub-template section should be absent"
+  );
+  assert!(
+    !output.contains("### Fargate Node"),
+    "Fargate sub-template section should be absent"
+  );
 }
 
 #[tokio::test]
 async fn playbook_fargate_section_present_others_absent() {
   let mut aws = fixtures::healthy_aws();
-  aws.fargate_profiles = vec![
-    FargateProfile::builder().fargate_profile_name("fp-1").build(),
-  ];
+  aws.fargate_profiles = vec![FargateProfile::builder().fargate_profile_name("fp-1").build()];
   let k8s = fixtures::healthy_k8s();
   let output = render_playbook(&aws, &k8s).await;
 
-  assert!(output.contains("### Fargate Node"), "Fargate sub-template section should be present");
-  assert!(!output.contains("#### EKS Managed Nodegroup"), "EKS MNG sub-template section should be absent");
-  assert!(!output.contains("#### Self-Managed Nodegroup"), "Self-managed sub-template section should be absent");
+  assert!(
+    output.contains("### Fargate Node"),
+    "Fargate sub-template section should be present"
+  );
+  assert!(
+    !output.contains("#### EKS Managed Nodegroup"),
+    "EKS MNG sub-template section should be absent"
+  );
+  assert!(
+    !output.contains("#### Self-Managed Nodegroup"),
+    "Self-managed sub-template section should be absent"
+  );
 }
 
 #[tokio::test]
@@ -323,8 +363,14 @@ async fn playbook_pod_ips_healthy_when_no_custom_networking() {
   let output = render_playbook(&aws, &k8s).await;
 
   // The pod IPs section renders with a healthy status when no custom networking issues exist
-  assert!(output.contains("sufficient IP space"), "pod IPs section should show healthy status");
-  assert!(output.contains("Check [[AWS002]]"), "pod IPs check reference should be present");
+  assert!(
+    output.contains("sufficient IP space"),
+    "pod IPs section should show healthy status"
+  );
+  assert!(
+    output.contains("Check [[AWS002]]"),
+    "pod IPs check reference should be present"
+  );
 }
 
 #[tokio::test]
@@ -334,7 +380,10 @@ async fn playbook_deprecation_url_absent_for_1_31_target() {
   let k8s = fixtures::healthy_k8s();
   let output = render_playbook(&aws, &k8s).await;
 
-  assert!(!output.contains("API deprecations"), "deprecation link should be absent for 1.31 target");
+  assert!(
+    !output.contains("API deprecations"),
+    "deprecation link should be absent for 1.31 target"
+  );
 }
 
 #[tokio::test]
@@ -344,6 +393,12 @@ async fn playbook_deprecation_url_present_for_1_32_target() {
   let k8s = fixtures::healthy_k8s();
   let output = render_playbook(&aws, &k8s).await;
 
-  assert!(output.contains("API deprecations"), "deprecation link should be present for 1.32 target");
-  assert!(output.contains("deprecation-guide/#v1-32"), "deprecation URL should point to 1.32 guide");
+  assert!(
+    output.contains("API deprecations"),
+    "deprecation link should be present for 1.32 target"
+  );
+  assert!(
+    output.contains("deprecation-guide/#v1-32"),
+    "deprecation URL should point to 1.32 guide"
+  );
 }

--- a/eksup/tests/integration.rs
+++ b/eksup/tests/integration.rs
@@ -1,8 +1,10 @@
 mod common;
 
 use common::{fixtures, mock_k8s::MockK8sClients};
-use eksup::config::{Config, K8s002Config, K8s004Config};
-use eksup::eks::resources::VpcSubnet;
+use eksup::{
+  config::{Config, K8s002Config, K8s004Config},
+  eks::resources::VpcSubnet,
+};
 
 // ============================================================================
 // Cluster findings
@@ -56,8 +58,16 @@ async fn subnet_findings_sufficient_ips() {
 async fn subnet_findings_insufficient_control_plane_ips() {
   let mut aws = fixtures::healthy_aws();
   aws.subnet_ips = vec![
-    VpcSubnet { id: "subnet-1".into(), available_ips: 3, availability_zone_id: "use1-az1".into() },
-    VpcSubnet { id: "subnet-2".into(), available_ips: 2, availability_zone_id: "use1-az2".into() },
+    VpcSubnet {
+      id: "subnet-1".into(),
+      available_ips: 3,
+      availability_zone_id: "use1-az1".into(),
+    },
+    VpcSubnet {
+      id: "subnet-2".into(),
+      available_ips: 2,
+      availability_zone_id: "use1-az2".into(),
+    },
   ];
   let k8s = fixtures::healthy_k8s();
 
@@ -72,26 +82,35 @@ async fn subnet_findings_insufficient_control_plane_ips() {
 #[tokio::test]
 async fn addon_findings_no_addons() {
   let aws = fixtures::healthy_aws();
-  let result = eksup::eks::get_addon_findings(&aws, "test-cluster", "1.30", 31).await.unwrap();
+  let result = eksup::eks::get_addon_findings(&aws, "test-cluster", "1.30", 31)
+    .await
+    .unwrap();
   assert!(result.version_compatibility.is_empty());
   assert!(result.health.is_empty());
 }
 
 #[tokio::test]
 async fn addon_findings_version_incompatible() {
-  use aws_sdk_eks::types::Addon;
   use std::collections::HashMap;
 
+  use aws_sdk_eks::types::Addon;
+
   let mut aws = fixtures::healthy_aws();
-  aws.addons = vec![
-    Addon::builder().addon_name("vpc-cni").addon_version("v1.12.0").build(),
-  ];
+  aws.addons = vec![Addon::builder().addon_name("vpc-cni").addon_version("v1.12.0").build()];
   aws.addon_versions = HashMap::from([
-    (("vpc-cni".into(), "1.30".into()), fixtures::make_addon_version("v1.15.0", "v1.14.0", &["v1.15.0", "v1.14.0"])),
-    (("vpc-cni".into(), "1.31".into()), fixtures::make_addon_version("v1.16.0", "v1.15.0", &["v1.16.0", "v1.15.0"])),
+    (
+      ("vpc-cni".into(), "1.30".into()),
+      fixtures::make_addon_version("v1.15.0", "v1.14.0", &["v1.15.0", "v1.14.0"]),
+    ),
+    (
+      ("vpc-cni".into(), "1.31".into()),
+      fixtures::make_addon_version("v1.16.0", "v1.15.0", &["v1.16.0", "v1.15.0"]),
+    ),
   ]);
 
-  let result = eksup::eks::get_addon_findings(&aws, "test-cluster", "1.30", 31).await.unwrap();
+  let result = eksup::eks::get_addon_findings(&aws, "test-cluster", "1.30", 31)
+    .await
+    .unwrap();
   assert_eq!(result.version_compatibility.len(), 1);
 }
 
@@ -102,7 +121,9 @@ async fn addon_findings_version_incompatible() {
 #[tokio::test]
 async fn data_plane_findings_empty() {
   let aws = fixtures::healthy_aws();
-  let result = eksup::eks::get_data_plane_findings(&aws, &aws.cluster, 31).await.unwrap();
+  let result = eksup::eks::get_data_plane_findings(&aws, &aws.cluster, 31)
+    .await
+    .unwrap();
   assert!(result.eks_managed_nodegroup_health.is_empty());
   assert!(result.eks_managed_nodegroup_update.is_empty());
   assert!(result.self_managed_nodegroup_update.is_empty());
@@ -121,11 +142,21 @@ async fn data_plane_findings_node_ips() {
       .build(),
   ];
   aws.subnet_ips = vec![
-    VpcSubnet { id: "subnet-1".into(), available_ips: 10, availability_zone_id: "use1-az1".into() },
-    VpcSubnet { id: "subnet-2".into(), available_ips: 10, availability_zone_id: "use1-az2".into() },
+    VpcSubnet {
+      id: "subnet-1".into(),
+      available_ips: 10,
+      availability_zone_id: "use1-az1".into(),
+    },
+    VpcSubnet {
+      id: "subnet-2".into(),
+      available_ips: 10,
+      availability_zone_id: "use1-az2".into(),
+    },
   ];
 
-  let result = eksup::eks::get_data_plane_findings(&aws, &aws.cluster, 31).await.unwrap();
+  let result = eksup::eks::get_data_plane_findings(&aws, &aws.cluster, 31)
+    .await
+    .unwrap();
   assert!(!result.node_ips.is_empty(), "low IP subnets should produce findings");
 }
 
@@ -136,7 +167,9 @@ async fn data_plane_findings_node_ips() {
 #[tokio::test]
 async fn kubernetes_findings_empty() {
   let k8s = fixtures::healthy_k8s();
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default()).await.unwrap();
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default())
+    .await
+    .unwrap();
   assert!(result.version_skew.is_empty());
   assert!(result.min_replicas.is_empty());
 }
@@ -148,7 +181,9 @@ async fn kubernetes_findings_version_skew() {
     ..Default::default()
   };
 
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default()).await.unwrap();
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default())
+    .await
+    .unwrap();
   assert_eq!(result.version_skew.len(), 1);
 }
 
@@ -159,16 +194,22 @@ async fn kubernetes_findings_workload_issues() {
     ..Default::default()
   };
 
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default()).await.unwrap();
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default())
+    .await
+    .unwrap();
   assert!(!result.min_replicas.is_empty(), "1 replica should trigger finding");
-  assert!(!result.readiness_probe.is_empty(), "missing probe should trigger finding");
+  assert!(
+    !result.readiness_probe.is_empty(),
+    "missing probe should trigger finding"
+  );
 }
 
 #[tokio::test]
 async fn kubernetes_findings_missing_pdb() {
   use std::collections::BTreeMap;
-  use k8s_openapi::api::core::v1::{Container, PodSpec, PodTemplateSpec};
+
   use eksup::k8s::resources::{Kind, StdMetadata, StdResource, StdSpec};
+  use k8s_openapi::api::core::v1::{Container, PodSpec, PodTemplateSpec};
 
   let labels = BTreeMap::from([("app".to_string(), "web".to_string())]);
   let deploy = StdResource {
@@ -188,7 +229,10 @@ async fn kubernetes_findings_missing_pdb() {
           ..Default::default()
         }),
         spec: Some(PodSpec {
-          containers: vec![Container { name: "app".into(), ..Default::default() }],
+          containers: vec![Container {
+            name: "app".into(),
+            ..Default::default()
+          }],
           ..Default::default()
         }),
       }),
@@ -200,8 +244,13 @@ async fn kubernetes_findings_missing_pdb() {
     ..Default::default()
   };
 
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default()).await.unwrap();
-  assert!(!result.pod_disruption_budgets.is_empty(), "missing PDB should trigger finding");
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default())
+    .await
+    .unwrap();
+  assert!(
+    !result.pod_disruption_budgets.is_empty(),
+    "missing PDB should trigger finding"
+  );
 }
 
 // ============================================================================
@@ -212,7 +261,9 @@ async fn kubernetes_findings_missing_pdb() {
 async fn analyze_healthy_cluster() {
   let aws = fixtures::healthy_aws();
   let k8s = fixtures::healthy_k8s();
-  let results = eksup::analysis::analyze(&aws, &k8s, &aws.cluster, 31, &Config::default()).await.unwrap();
+  let results = eksup::analysis::analyze(&aws, &k8s, &aws.cluster, 31, &Config::default())
+    .await
+    .unwrap();
 
   assert!(results.cluster.cluster_health.is_empty());
   assert!(results.subnets.control_plane_ips.is_empty());
@@ -229,7 +280,9 @@ async fn analyze_filter_recommended() {
   };
   let aws = fixtures::healthy_aws();
 
-  let mut results = eksup::analysis::analyze(&aws, &k8s, &aws.cluster, 31, &Config::default()).await.unwrap();
+  let mut results = eksup::analysis::analyze(&aws, &k8s, &aws.cluster, 31, &Config::default())
+    .await
+    .unwrap();
   let before_skew = results.kubernetes.version_skew.len();
   results.filter_recommended();
   // Version skew of 1 is Recommended, so it should be filtered out
@@ -246,7 +299,9 @@ async fn analyze_with_explicit_target() {
   let k8s = fixtures::healthy_k8s();
 
   // Jump from 1.30 → 1.33
-  let results = eksup::analysis::analyze(&aws, &k8s, &aws.cluster, 33, &Config::default()).await.unwrap();
+  let results = eksup::analysis::analyze(&aws, &k8s, &aws.cluster, 33, &Config::default())
+    .await
+    .unwrap();
 
   assert!(results.cluster.cluster_health.is_empty());
   assert!(results.subnets.control_plane_ips.is_empty());
@@ -259,13 +314,23 @@ async fn analyze_with_explicit_target() {
 #[tokio::test]
 async fn service_limit_findings_healthy() {
   use std::collections::HashMap;
+
   use eksup::eks::resources::quota_codes;
 
   let mut aws = fixtures::healthy_aws();
   aws.service_quotas = HashMap::from([
-    (("ec2".into(), quota_codes::EC2_ON_DEMAND_STANDARD.into()), ("Running On-Demand Standard Instances".into(), 256.0, "vCPUs".into())),
-    (("ebs".into(), quota_codes::EBS_GP2_STORAGE.into()), ("GP2 Storage".into(), 50.0, "TiB".into())),
-    (("ebs".into(), quota_codes::EBS_GP3_STORAGE.into()), ("GP3 Storage".into(), 50.0, "TiB".into())),
+    (
+      ("ec2".into(), quota_codes::EC2_ON_DEMAND_STANDARD.into()),
+      ("Running On-Demand Standard Instances".into(), 256.0, "vCPUs".into()),
+    ),
+    (
+      ("ebs".into(), quota_codes::EBS_GP2_STORAGE.into()),
+      ("GP2 Storage".into(), 50.0, "TiB".into()),
+    ),
+    (
+      ("ebs".into(), quota_codes::EBS_GP3_STORAGE.into()),
+      ("GP3 Storage".into(), 50.0, "TiB".into()),
+    ),
   ]);
   aws.ec2_vcpu_count = 32.0;
   aws.ebs_storage = HashMap::from([("gp2".into(), 5.0), ("gp3".into(), 10.0)]);
@@ -279,13 +344,23 @@ async fn service_limit_findings_healthy() {
 #[tokio::test]
 async fn service_limit_findings_high_usage() {
   use std::collections::HashMap;
+
   use eksup::eks::resources::quota_codes;
 
   let mut aws = fixtures::healthy_aws();
   aws.service_quotas = HashMap::from([
-    (("ec2".into(), quota_codes::EC2_ON_DEMAND_STANDARD.into()), ("Running On-Demand Standard Instances".into(), 100.0, "vCPUs".into())),
-    (("ebs".into(), quota_codes::EBS_GP2_STORAGE.into()), ("GP2 Storage".into(), 50.0, "TiB".into())),
-    (("ebs".into(), quota_codes::EBS_GP3_STORAGE.into()), ("GP3 Storage".into(), 50.0, "TiB".into())),
+    (
+      ("ec2".into(), quota_codes::EC2_ON_DEMAND_STANDARD.into()),
+      ("Running On-Demand Standard Instances".into(), 100.0, "vCPUs".into()),
+    ),
+    (
+      ("ebs".into(), quota_codes::EBS_GP2_STORAGE.into()),
+      ("GP2 Storage".into(), 50.0, "TiB".into()),
+    ),
+    (
+      ("ebs".into(), quota_codes::EBS_GP3_STORAGE.into()),
+      ("GP3 Storage".into(), 50.0, "TiB".into()),
+    ),
   ]);
   aws.ec2_vcpu_count = 92.0; // 92% usage
   aws.ebs_storage = HashMap::from([("gp2".into(), 2.0), ("gp3".into(), 2.0)]);
@@ -331,26 +406,67 @@ async fn insights_findings_with_issues() {
   ];
 
   let result = eksup::eks::get_insights_findings(&aws, "test-cluster").await.unwrap();
-  assert_eq!(result.upgrade_readiness.len(), 1, "should have 1 upgrade readiness insight");
-  assert_eq!(result.misconfiguration.len(), 1, "should have 1 misconfiguration insight");
+  assert_eq!(
+    result.upgrade_readiness.len(),
+    1,
+    "should have 1 upgrade readiness insight"
+  );
+  assert_eq!(
+    result.misconfiguration.len(),
+    1,
+    "should have 1 misconfiguration insight"
+  );
 }
 
 #[tokio::test]
 async fn insights_findings_status_mapping() {
   let mut aws = fixtures::healthy_aws();
   aws.insights = vec![
-    fixtures::make_insight("id-1", "Error insight", "UPGRADE_READINESS", "ERROR", "1.31", "desc", "rec"),
-    fixtures::make_insight("id-2", "Warning insight", "UPGRADE_READINESS", "WARNING", "1.31", "desc", "rec"),
-    fixtures::make_insight("id-3", "Unknown insight", "UPGRADE_READINESS", "UNKNOWN", "1.31", "desc", "rec"),
+    fixtures::make_insight(
+      "id-1",
+      "Error insight",
+      "UPGRADE_READINESS",
+      "ERROR",
+      "1.31",
+      "desc",
+      "rec",
+    ),
+    fixtures::make_insight(
+      "id-2",
+      "Warning insight",
+      "UPGRADE_READINESS",
+      "WARNING",
+      "1.31",
+      "desc",
+      "rec",
+    ),
+    fixtures::make_insight(
+      "id-3",
+      "Unknown insight",
+      "UPGRADE_READINESS",
+      "UNKNOWN",
+      "1.31",
+      "desc",
+      "rec",
+    ),
   ];
 
   let result = eksup::eks::get_insights_findings(&aws, "test-cluster").await.unwrap();
   assert_eq!(result.upgrade_readiness.len(), 3);
 
   use eksup::finding::Remediation;
-  assert!(matches!(result.upgrade_readiness[0].finding.remediation, Remediation::Required));
-  assert!(matches!(result.upgrade_readiness[1].finding.remediation, Remediation::Recommended));
-  assert!(matches!(result.upgrade_readiness[2].finding.remediation, Remediation::Recommended));
+  assert!(matches!(
+    result.upgrade_readiness[0].finding.remediation,
+    Remediation::Required
+  ));
+  assert!(matches!(
+    result.upgrade_readiness[1].finding.remediation,
+    Remediation::Recommended
+  ));
+  assert!(matches!(
+    result.upgrade_readiness[2].finding.remediation,
+    Remediation::Recommended
+  ));
 }
 
 // ============================================================================
@@ -359,15 +475,21 @@ async fn insights_findings_status_mapping() {
 
 #[tokio::test]
 async fn analyze_aws_error_propagates() {
-  use common::mock_aws::MockAwsClientsError;
-  use common::mock_k8s::MockK8sClientsError;
+  use common::{mock_aws::MockAwsClientsError, mock_k8s::MockK8sClientsError};
 
   let cluster = aws_sdk_eks::types::Cluster::builder()
     .name("test")
     .version("1.30")
     .build();
 
-  let result = eksup::analysis::analyze(&MockAwsClientsError, &MockK8sClientsError, &cluster, 31, &Config::default()).await;
+  let result = eksup::analysis::analyze(
+    &MockAwsClientsError,
+    &MockK8sClientsError,
+    &cluster,
+    31,
+    &Config::default(),
+  )
+  .await;
   assert!(result.is_err(), "should propagate AWS/K8s errors");
 }
 
@@ -382,8 +504,13 @@ async fn kubernetes_findings_min_replicas_default_threshold() {
     resources: vec![fixtures::make_deployment("web", "default", 2)],
     ..Default::default()
   };
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default()).await.unwrap();
-  assert!(result.min_replicas.is_empty(), "2 replicas should pass with default threshold of 2");
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default())
+    .await
+    .unwrap();
+  assert!(
+    result.min_replicas.is_empty(),
+    "2 replicas should pass with default threshold of 2"
+  );
 }
 
 #[tokio::test]
@@ -393,9 +520,18 @@ async fn kubernetes_findings_min_replicas_strict_threshold() {
     resources: vec![fixtures::make_deployment("web", "default", 2)],
     ..Default::default()
   };
-  let strict = K8s002Config { min_replicas: 3, ..Default::default() };
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &strict, &K8s004Config::default()).await.unwrap();
-  assert_eq!(result.min_replicas.len(), 1, "2 replicas should fail with threshold of 3");
+  let strict = K8s002Config {
+    min_replicas: 3,
+    ..Default::default()
+  };
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &strict, &K8s004Config::default())
+    .await
+    .unwrap();
+  assert_eq!(
+    result.min_replicas.len(),
+    1,
+    "2 replicas should fail with threshold of 3"
+  );
 }
 
 #[tokio::test]
@@ -411,8 +547,13 @@ async fn kubernetes_findings_min_replicas_ignored() {
     }],
     ..Default::default()
   };
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &config, &K8s004Config::default()).await.unwrap();
-  assert!(result.min_replicas.is_empty(), "ignored workload should not trigger finding");
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &config, &K8s004Config::default())
+    .await
+    .unwrap();
+  assert!(
+    result.min_replicas.is_empty(),
+    "ignored workload should not trigger finding"
+  );
 }
 
 #[tokio::test]
@@ -432,7 +573,9 @@ async fn kubernetes_findings_min_replicas_per_workload_override() {
     }],
     ..Default::default()
   };
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &config, &K8s004Config::default()).await.unwrap();
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &config, &K8s004Config::default())
+    .await
+    .unwrap();
   assert_eq!(result.min_replicas.len(), 1, "only etcd should fail (3 < 5)");
   assert_eq!(result.min_replicas[0].resource.name, "etcd");
 }
@@ -444,8 +587,9 @@ async fn kubernetes_findings_min_replicas_per_workload_override() {
 #[tokio::test]
 async fn kubernetes_findings_pdb_ignored() {
   use std::collections::BTreeMap;
-  use k8s_openapi::api::core::v1::{Container, PodSpec, PodTemplateSpec};
+
   use eksup::k8s::resources::{Kind, StdMetadata, StdResource, StdSpec};
+  use k8s_openapi::api::core::v1::{Container, PodSpec, PodTemplateSpec};
 
   let labels = BTreeMap::from([("app".to_string(), "web".to_string())]);
   let deploy = StdResource {
@@ -465,7 +609,10 @@ async fn kubernetes_findings_pdb_ignored() {
           ..Default::default()
         }),
         spec: Some(PodSpec {
-          containers: vec![Container { name: "app".into(), ..Default::default() }],
+          containers: vec![Container {
+            name: "app".into(),
+            ..Default::default()
+          }],
           ..Default::default()
         }),
       }),
@@ -478,8 +625,13 @@ async fn kubernetes_findings_pdb_ignored() {
   };
 
   // Without ignore: should trigger PDB finding
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default()).await.unwrap();
-  assert!(!result.pod_disruption_budgets.is_empty(), "missing PDB should trigger finding");
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &K8s004Config::default())
+    .await
+    .unwrap();
+  assert!(
+    !result.pod_disruption_budgets.is_empty(),
+    "missing PDB should trigger finding"
+  );
 
   // With ignore: should NOT trigger
   let config = K8s004Config {
@@ -488,6 +640,11 @@ async fn kubernetes_findings_pdb_ignored() {
       namespace: "default".into(),
     }],
   };
-  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &config).await.unwrap();
-  assert!(result.pod_disruption_budgets.is_empty(), "ignored workload should not trigger PDB finding");
+  let result = eksup::k8s::get_kubernetes_findings(&k8s, 30, 31, &K8s002Config::default(), &config)
+    .await
+    .unwrap();
+  assert!(
+    result.pod_disruption_budgets.is_empty(),
+    "ignored workload should not trigger PDB finding"
+  );
 }

--- a/man/eksup.1
+++ b/man/eksup.1
@@ -1,0 +1,42 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH eksup 1  "eksup 0.13.0" 
+.SH NAME
+eksup \- A CLI to aid in upgrading Amazon EKS clusters
+.SH SYNOPSIS
+\fBeksup\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-q\fR|\fB\-\-quiet\fR]... [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+A CLI to aid in upgrading Amazon EKS clusters
+.SH OPTIONS
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Increase logging verbosity
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Decrease logging verbosity
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version
+.SH SUBCOMMANDS
+.TP
+eksup\-analyze(1)
+Analyze an Amazon EKS cluster for potential upgrade issues
+.TP
+eksup\-create(1)
+Create artifacts using the analysis data
+.TP
+eksup\-completion(1)
+Generate shell completion script for the given shell
+.TP
+eksup\-man(1)
+Generate the man page for eksup
+.TP
+eksup\-help(1)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.13.0
+.SH AUTHORS
+Bryant Biggs <bryantbiggs@gmail.com>

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -12,6 +12,8 @@ nav:
     - Usage: info/usage.md
     - Checks: info/checks.md
     - Design: info/design.md
+  - Install:
+    - Shell Completions: install/shell-completions.md
 
 theme:
   name: material

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,3 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { version = "1", default-features = false, features = ["std"] }
+eksup = { path = "../eksup" }
+clap = { version = "4.6", default-features = false, features = ["std", "derive"] }
+clap_complete = { version = "4.5", default-features = false }
+clap_mangen = { version = "0.2", default-features = false }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,277 +1,269 @@
+use std::path::Path;
+
 use anyhow::{Context, Result, bail};
 use clap::CommandFactory;
 use clap_complete::{Generator, Shell, generate};
-use std::path::Path;
 
 /// Parsed check code from `define_codes!`
 struct CheckCode {
-    name: String,
-    description: String,
-    from: Option<i32>,
-    until: Option<i32>,
+  name: String,
+  description: String,
+  from: Option<i32>,
+  until: Option<i32>,
 }
 
 fn main() -> Result<()> {
-    let args: Vec<String> = std::env::args().collect();
-    match args.get(1).map(|s| s.as_str()) {
-        Some("generate-docs") => {
-            let check_mode = args.iter().any(|a| a == "--check");
-            generate_docs(check_mode)
-        }
-        Some("generate-completions") => {
-            let check_mode = args.iter().any(|a| a == "--check");
-            generate_completions(check_mode)
-        }
-        Some("generate-man") => {
-            let check_mode = args.iter().any(|a| a == "--check");
-            generate_man(check_mode)
-        }
-        Some("generate-all") => {
-            let check_mode = args.iter().any(|a| a == "--check");
-            generate_all(check_mode)
-        }
-        _ => {
-            eprintln!(
-                "Usage: cargo xtask <generate-docs|generate-completions|generate-man|generate-all> [--check]"
-            );
-            std::process::exit(1);
-        }
+  let args: Vec<String> = std::env::args().collect();
+  match args.get(1).map(|s| s.as_str()) {
+    Some("generate-docs") => {
+      let check_mode = args.iter().any(|a| a == "--check");
+      generate_docs(check_mode)
     }
+    Some("generate-completions") => {
+      let check_mode = args.iter().any(|a| a == "--check");
+      generate_completions(check_mode)
+    }
+    Some("generate-man") => {
+      let check_mode = args.iter().any(|a| a == "--check");
+      generate_man(check_mode)
+    }
+    Some("generate-all") => {
+      let check_mode = args.iter().any(|a| a == "--check");
+      generate_all(check_mode)
+    }
+    _ => {
+      eprintln!("Usage: cargo xtask <generate-docs|generate-completions|generate-man|generate-all> [--check]");
+      std::process::exit(1);
+    }
+  }
 }
 
 fn generate_docs(check_mode: bool) -> Result<()> {
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
-    let finding_rs = workspace_root.join("eksup/src/finding.rs");
-    let version_rs = workspace_root.join("eksup/src/version.rs");
-    let checks_md = workspace_root.join("docs/info/checks.md");
+  let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+  let finding_rs = workspace_root.join("eksup/src/finding.rs");
+  let version_rs = workspace_root.join("eksup/src/version.rs");
+  let checks_md = workspace_root.join("docs/info/checks.md");
 
-    let finding_src = std::fs::read_to_string(&finding_rs)
-        .with_context(|| format!("Failed to read {}", finding_rs.display()))?;
-    let version_src = std::fs::read_to_string(&version_rs)
-        .with_context(|| format!("Failed to read {}", version_rs.display()))?;
+  let finding_src =
+    std::fs::read_to_string(&finding_rs).with_context(|| format!("Failed to read {}", finding_rs.display()))?;
+  let version_src =
+    std::fs::read_to_string(&version_rs).with_context(|| format!("Failed to read {}", version_rs.display()))?;
 
-    let minimum = parse_minimum(&version_src)?;
-    let codes = parse_define_codes(&finding_src)?;
-    let table = generate_checks_table(&codes, minimum);
+  let minimum = parse_minimum(&version_src)?;
+  let codes = parse_define_codes(&finding_src)?;
+  let table = generate_checks_table(&codes, minimum);
 
-    let current_content = std::fs::read_to_string(&checks_md)
-        .with_context(|| format!("Failed to read {}", checks_md.display()))?;
+  let current_content =
+    std::fs::read_to_string(&checks_md).with_context(|| format!("Failed to read {}", checks_md.display()))?;
 
-    let new_content = splice_generated_section(&current_content, &table)?;
+  let new_content = splice_generated_section(&current_content, &table)?;
 
-    if check_mode {
-        if current_content != new_content {
-            bail!(
-                "docs/info/checks.md is out of date. Run `cargo xtask generate-docs` to update it."
-            );
-        }
-        println!("docs/info/checks.md is up to date.");
-    } else {
-        std::fs::write(&checks_md, &new_content)?;
-        println!("Updated docs/info/checks.md");
+  if check_mode {
+    if current_content != new_content {
+      bail!("docs/info/checks.md is out of date. Run `cargo xtask generate-docs` to update it.");
     }
+    println!("docs/info/checks.md is up to date.");
+  } else {
+    std::fs::write(&checks_md, &new_content)?;
+    println!("Updated docs/info/checks.md");
+  }
 
-    Ok(())
+  Ok(())
 }
 
 fn parse_minimum(version_src: &str) -> Result<i32> {
-    for line in version_src.lines() {
-        let line = line.trim();
-        if line.starts_with("pub const MINIMUM: i32 =") {
-            let value = line
-                .trim_start_matches("pub const MINIMUM: i32 =")
-                .trim()
-                .trim_end_matches(';')
-                .trim();
-            return value.parse::<i32>().context("Failed to parse MINIMUM value");
-        }
+  for line in version_src.lines() {
+    let line = line.trim();
+    if line.starts_with("pub const MINIMUM: i32 =") {
+      let value = line
+        .trim_start_matches("pub const MINIMUM: i32 =")
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+      return value.parse::<i32>().context("Failed to parse MINIMUM value");
     }
-    bail!("Could not find `pub const MINIMUM: i32 = ...` in version.rs")
+  }
+  bail!("Could not find `pub const MINIMUM: i32 = ...` in version.rs")
 }
 
 fn parse_define_codes(src: &str) -> Result<Vec<CheckCode>> {
-    let mut codes = Vec::new();
-    let mut in_macro = false;
+  let mut codes = Vec::new();
+  let mut in_macro = false;
 
-    for line in src.lines() {
-        let trimmed = line.trim();
+  for line in src.lines() {
+    let trimmed = line.trim();
 
-        if trimmed.starts_with("define_codes!") {
-            in_macro = true;
-            continue;
-        }
-
-        if !in_macro {
-            continue;
-        }
-
-        // End of macro
-        if trimmed == "}" {
-            break;
-        }
-
-        // Match lines like: AWS001 => { desc: "...", from: None, until: None },
-        if trimmed.contains("=>") && trimmed.contains("desc:") {
-            let name = trimmed.split("=>").next().unwrap().trim().to_string();
-
-            let desc = extract_quoted_value(trimmed, "desc:")
-                .context(format!("Failed to parse desc for {name}"))?;
-            let from = extract_option_value(trimmed, "from:");
-            let until = extract_option_value(trimmed, "until:");
-
-            codes.push(CheckCode {
-                name,
-                description: desc,
-                from,
-                until,
-            });
-        }
+    if trimmed.starts_with("define_codes!") {
+      in_macro = true;
+      continue;
     }
 
-    if codes.is_empty() {
-        bail!("No check codes found in define_codes! macro");
+    if !in_macro {
+      continue;
     }
 
-    Ok(codes)
+    // End of macro
+    if trimmed == "}" {
+      break;
+    }
+
+    // Match lines like: AWS001 => { desc: "...", from: None, until: None },
+    if trimmed.contains("=>") && trimmed.contains("desc:") {
+      let name = trimmed.split("=>").next().unwrap().trim().to_string();
+
+      let desc = extract_quoted_value(trimmed, "desc:").context(format!("Failed to parse desc for {name}"))?;
+      let from = extract_option_value(trimmed, "from:");
+      let until = extract_option_value(trimmed, "until:");
+
+      codes.push(CheckCode {
+        name,
+        description: desc,
+        from,
+        until,
+      });
+    }
+  }
+
+  if codes.is_empty() {
+    bail!("No check codes found in define_codes! macro");
+  }
+
+  Ok(codes)
 }
 
 fn extract_quoted_value(line: &str, key: &str) -> Option<String> {
-    let after_key = line.split(key).nth(1)?;
-    let start = after_key.find('"')? + 1;
-    let end = start + after_key[start..].find('"')?;
-    Some(after_key[start..end].to_string())
+  let after_key = line.split(key).nth(1)?;
+  let start = after_key.find('"')? + 1;
+  let end = start + after_key[start..].find('"')?;
+  Some(after_key[start..end].to_string())
 }
 
 fn extract_option_value(line: &str, key: &str) -> Option<i32> {
-    let after_key = line.split(key).nth(1)?;
-    let trimmed = after_key.trim();
-    if trimmed.starts_with("None") {
-        None
-    } else if trimmed.starts_with("Some(") {
-        let start = 5; // len("Some(")
-        let end = trimmed.find(')')?;
-        trimmed[start..end].trim().parse().ok()
-    } else {
-        None
-    }
+  let after_key = line.split(key).nth(1)?;
+  let trimmed = after_key.trim();
+  if trimmed.starts_with("None") {
+    None
+  } else if trimmed.starts_with("Some(") {
+    let start = 5; // len("Some(")
+    let end = trimmed.find(')')?;
+    trimmed[start..end].trim().parse().ok()
+  } else {
+    None
+  }
 }
 
 fn generate_checks_table(codes: &[CheckCode], minimum: i32) -> String {
-    let mut lines = Vec::new();
+  let mut lines = Vec::new();
 
-    lines.push("| Code | Description | Status | Applicable Versions |".to_string());
-    lines.push("| :--- | :---------- | :----- | :------------------ |".to_string());
+  lines.push("| Code | Description | Status | Applicable Versions |".to_string());
+  lines.push("| :--- | :---------- | :----- | :------------------ |".to_string());
 
-    for code in codes {
-        let is_retired = code.until.map_or(false, |u| u < minimum);
-        let status = if is_retired { "Retired" } else { "Active" };
+  for code in codes {
+    let is_retired = code.until.is_some_and(|u| u < minimum);
+    let status = if is_retired { "Retired" } else { "Active" };
 
-        let versions = match (code.from, code.until) {
-            (None, None) => "All versions".to_string(),
-            (Some(f), None) => format!("1.{f}+"),
-            (None, Some(u)) => format!("Up to 1.{u}"),
-            (Some(f), Some(u)) => format!("1.{f} - 1.{u}"),
-        };
+    let versions = match (code.from, code.until) {
+      (None, None) => "All versions".to_string(),
+      (Some(f), None) => format!("1.{f}+"),
+      (None, Some(u)) => format!("Up to 1.{u}"),
+      (Some(f), Some(u)) => format!("1.{f} - 1.{u}"),
+    };
 
-        lines.push(format!(
-            "| `{code}` | {desc} | {status} | {versions} |",
-            code = code.name,
-            desc = code.description,
-            status = status,
-            versions = versions,
-        ));
-    }
+    lines.push(format!(
+      "| `{code}` | {desc} | {status} | {versions} |",
+      code = code.name,
+      desc = code.description,
+      status = status,
+      versions = versions,
+    ));
+  }
 
-    lines.join("\n")
+  lines.join("\n")
 }
 
 fn splice_generated_section(content: &str, table: &str) -> Result<String> {
-    let begin_marker = "<!-- BEGIN GENERATED CHECKS TABLE -->";
-    let end_marker = "<!-- END GENERATED CHECKS TABLE -->";
+  let begin_marker = "<!-- BEGIN GENERATED CHECKS TABLE -->";
+  let end_marker = "<!-- END GENERATED CHECKS TABLE -->";
 
-    let begin_pos = content
-        .find(begin_marker)
-        .context("Missing '<!-- BEGIN GENERATED CHECKS TABLE -->' marker in checks.md")?;
-    let end_pos = content
-        .find(end_marker)
-        .context("Missing '<!-- END GENERATED CHECKS TABLE -->' marker in checks.md")?;
+  let begin_pos = content
+    .find(begin_marker)
+    .context("Missing '<!-- BEGIN GENERATED CHECKS TABLE -->' marker in checks.md")?;
+  let end_pos = content
+    .find(end_marker)
+    .context("Missing '<!-- END GENERATED CHECKS TABLE -->' marker in checks.md")?;
 
-    let before = &content[..begin_pos + begin_marker.len()];
-    let after = &content[end_pos..];
+  let before = &content[..begin_pos + begin_marker.len()];
+  let after = &content[end_pos..];
 
-    Ok(format!("{before}\n\n{table}\n\n{after}"))
+  Ok(format!("{before}\n\n{table}\n\n{after}"))
 }
 
 fn generate_completions(check_mode: bool) -> Result<()> {
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
-    let out_dir = workspace_root.join("completions");
+  let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+  let out_dir = workspace_root.join("completions");
 
-    let mut cmd = eksup::Cli::command();
+  let mut cmd = eksup::Cli::command();
 
-    for shell in [Shell::Bash, Shell::Elvish, Shell::Fish, Shell::PowerShell, Shell::Zsh] {
-        let mut buf = Vec::new();
-        generate(shell, &mut cmd, "eksup", &mut buf);
+  for shell in [Shell::Bash, Shell::Elvish, Shell::Fish, Shell::PowerShell, Shell::Zsh] {
+    let mut buf = Vec::new();
+    generate(shell, &mut cmd, "eksup", &mut buf);
 
-        let filename = Generator::file_name(&shell, "eksup");
-        let final_path = out_dir.join(&filename);
-
-        if check_mode {
-            let current = std::fs::read(&final_path).unwrap_or_default();
-            if current != buf {
-                bail!(
-                    "{} is out of date. Run `cargo xtask generate-completions`.",
-                    final_path.display()
-                );
-            }
-        } else {
-            std::fs::create_dir_all(&out_dir)
-                .with_context(|| format!("Failed to create {}", out_dir.display()))?;
-            std::fs::write(&final_path, &buf)
-                .with_context(|| format!("Failed to write {}", final_path.display()))?;
-            println!("Updated {}", final_path.display());
-        }
-    }
+    let filename = Generator::file_name(&shell, "eksup");
+    let final_path = out_dir.join(&filename);
 
     if check_mode {
-        println!("completions/ is up to date.");
+      let current = std::fs::read(&final_path).unwrap_or_default();
+      if current != buf {
+        bail!(
+          "{} is out of date. Run `cargo xtask generate-completions`.",
+          final_path.display()
+        );
+      }
+    } else {
+      std::fs::create_dir_all(&out_dir).with_context(|| format!("Failed to create {}", out_dir.display()))?;
+      std::fs::write(&final_path, &buf).with_context(|| format!("Failed to write {}", final_path.display()))?;
+      println!("Updated {}", final_path.display());
     }
+  }
 
-    Ok(())
+  if check_mode {
+    println!("completions/ is up to date.");
+  }
+
+  Ok(())
 }
 
 fn generate_man(check_mode: bool) -> Result<()> {
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
-    let out_dir = workspace_root.join("man");
-    let final_path = out_dir.join("eksup.1");
+  let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+  let out_dir = workspace_root.join("man");
+  let final_path = out_dir.join("eksup.1");
 
-    let mut buf = Vec::new();
-    clap_mangen::Man::new(eksup::Cli::command())
-        .render(&mut buf)
-        .with_context(|| "Failed to render man page")?;
+  let mut buf = Vec::new();
+  clap_mangen::Man::new(eksup::Cli::command())
+    .render(&mut buf)
+    .with_context(|| "Failed to render man page")?;
 
-    if check_mode {
-        let current = std::fs::read(&final_path).unwrap_or_default();
-        if current != buf {
-            bail!(
-                "{} is out of date. Run `cargo xtask generate-man`.",
-                final_path.display()
-            );
-        }
-        println!("man/eksup.1 is up to date.");
-    } else {
-        std::fs::create_dir_all(&out_dir)
-            .with_context(|| format!("Failed to create {}", out_dir.display()))?;
-        std::fs::write(&final_path, &buf)
-            .with_context(|| format!("Failed to write {}", final_path.display()))?;
-        println!("Updated {}", final_path.display());
+  if check_mode {
+    let current = std::fs::read(&final_path).unwrap_or_default();
+    if current != buf {
+      bail!(
+        "{} is out of date. Run `cargo xtask generate-man`.",
+        final_path.display()
+      );
     }
+    println!("man/eksup.1 is up to date.");
+  } else {
+    std::fs::create_dir_all(&out_dir).with_context(|| format!("Failed to create {}", out_dir.display()))?;
+    std::fs::write(&final_path, &buf).with_context(|| format!("Failed to write {}", final_path.display()))?;
+    println!("Updated {}", final_path.display());
+  }
 
-    Ok(())
+  Ok(())
 }
 
 fn generate_all(check_mode: bool) -> Result<()> {
-    generate_docs(check_mode)?;
-    generate_completions(check_mode)?;
-    generate_man(check_mode)?;
-    Ok(())
+  generate_docs(check_mode)?;
+  generate_completions(check_mode)?;
+  generate_man(check_mode)?;
+  Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,6 @@
 use anyhow::{Context, Result, bail};
+use clap::CommandFactory;
+use clap_complete::{Generator, Shell, generate};
 use std::path::Path;
 
 /// Parsed check code from `define_codes!`
@@ -16,8 +18,12 @@ fn main() -> Result<()> {
             let check_mode = args.iter().any(|a| a == "--check");
             generate_docs(check_mode)
         }
+        Some("generate-completions") => {
+            let check_mode = args.iter().any(|a| a == "--check");
+            generate_completions(check_mode)
+        }
         _ => {
-            eprintln!("Usage: cargo xtask generate-docs [--check]");
+            eprintln!("Usage: cargo xtask <generate-docs|generate-completions> [--check]");
             std::process::exit(1);
         }
     }
@@ -184,4 +190,41 @@ fn splice_generated_section(content: &str, table: &str) -> Result<String> {
     let after = &content[end_pos..];
 
     Ok(format!("{before}\n\n{table}\n\n{after}"))
+}
+
+fn generate_completions(check_mode: bool) -> Result<()> {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let out_dir = workspace_root.join("completions");
+
+    let mut cmd = eksup::Cli::command();
+
+    for shell in [Shell::Bash, Shell::Elvish, Shell::Fish, Shell::PowerShell, Shell::Zsh] {
+        let mut buf = Vec::new();
+        generate(shell, &mut cmd, "eksup", &mut buf);
+
+        let filename = Generator::file_name(&shell, "eksup");
+        let final_path = out_dir.join(&filename);
+
+        if check_mode {
+            let current = std::fs::read(&final_path).unwrap_or_default();
+            if current != buf {
+                bail!(
+                    "{} is out of date. Run `cargo xtask generate-completions`.",
+                    final_path.display()
+                );
+            }
+        } else {
+            std::fs::create_dir_all(&out_dir)
+                .with_context(|| format!("Failed to create {}", out_dir.display()))?;
+            std::fs::write(&final_path, &buf)
+                .with_context(|| format!("Failed to write {}", final_path.display()))?;
+            println!("Updated {}", final_path.display());
+        }
+    }
+
+    if check_mode {
+        println!("completions/ is up to date.");
+    }
+
+    Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,8 +22,12 @@ fn main() -> Result<()> {
             let check_mode = args.iter().any(|a| a == "--check");
             generate_completions(check_mode)
         }
+        Some("generate-man") => {
+            let check_mode = args.iter().any(|a| a == "--check");
+            generate_man(check_mode)
+        }
         _ => {
-            eprintln!("Usage: cargo xtask <generate-docs|generate-completions> [--check]");
+            eprintln!("Usage: cargo xtask <generate-docs|generate-completions|generate-man> [--check]");
             std::process::exit(1);
         }
     }
@@ -224,6 +228,36 @@ fn generate_completions(check_mode: bool) -> Result<()> {
 
     if check_mode {
         println!("completions/ is up to date.");
+    }
+
+    Ok(())
+}
+
+fn generate_man(check_mode: bool) -> Result<()> {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let out_dir = workspace_root.join("man");
+    let final_path = out_dir.join("eksup.1");
+
+    let mut buf = Vec::new();
+    clap_mangen::Man::new(eksup::Cli::command())
+        .render(&mut buf)
+        .with_context(|| "Failed to render man page")?;
+
+    if check_mode {
+        let current = std::fs::read(&final_path).unwrap_or_default();
+        if current != buf {
+            bail!(
+                "{} is out of date. Run `cargo xtask generate-man`.",
+                final_path.display()
+            );
+        }
+        println!("man/eksup.1 is up to date.");
+    } else {
+        std::fs::create_dir_all(&out_dir)
+            .with_context(|| format!("Failed to create {}", out_dir.display()))?;
+        std::fs::write(&final_path, &buf)
+            .with_context(|| format!("Failed to write {}", final_path.display()))?;
+        println!("Updated {}", final_path.display());
     }
 
     Ok(())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,8 +26,14 @@ fn main() -> Result<()> {
             let check_mode = args.iter().any(|a| a == "--check");
             generate_man(check_mode)
         }
+        Some("generate-all") => {
+            let check_mode = args.iter().any(|a| a == "--check");
+            generate_all(check_mode)
+        }
         _ => {
-            eprintln!("Usage: cargo xtask <generate-docs|generate-completions|generate-man> [--check]");
+            eprintln!(
+                "Usage: cargo xtask <generate-docs|generate-completions|generate-man|generate-all> [--check]"
+            );
             std::process::exit(1);
         }
     }
@@ -260,5 +266,12 @@ fn generate_man(check_mode: bool) -> Result<()> {
         println!("Updated {}", final_path.display());
     }
 
+    Ok(())
+}
+
+fn generate_all(check_mode: bool) -> Result<()> {
+    generate_docs(check_mode)?;
+    generate_completions(check_mode)?;
+    generate_man(check_mode)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds shell completion and man page generation to `eksup`, delivered via two complementary surfaces. Resolves #155.

- **Runtime subcommands**: `eksup completion <shell>` (bash, zsh, fish, powershell, elvish) and `eksup man` write to stdout — both via `clap_complete` / `clap_mangen` against the existing `Cli` derive, no parallel CLI definition.
- **Pre-generated artifacts**: `completions/{eksup.bash,_eksup,_eksup.ps1,eksup.fish,eksup.elv}` and `man/eksup.1` committed to the repo, marked `linguist-generated`, and shipped in release tarballs (single-line `cp` in `release.yaml`). Three new xtask subcommands (`generate-completions`, `generate-man`, `generate-all`) regenerate them; all support `--check` mode.
- **New PR CI workflow** (`check.yaml`): the repo had no PR CI of any kind. New workflow runs `cargo +nightly fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all`, and `cargo xtask generate-all --check` on every PR. Existing `docs.yaml` simplified to deploy-only since the freshness check moved into `check.yaml`.
- **Docs**: new `docs/install/shell-completions.md` page with per-shell install commands and a new top-level `Install` nav section in `mkdocs.yaml`. README gains a `### Shell completions` subsection inside the existing `## Installation` block.
- **Prereq cleanup**: one `chore:` commit fixes pre-existing formatting drift (workspace-wide `cargo +nightly fmt`) and three latent clippy lints (`map_or` → `is_some_and`, `collapsible_match`, `needless_update`) so the new strict CI passes on day one.

16 commits, intentionally split for reviewability — see `git log --oneline main..HEAD`.

## Test Plan

- [x] `cargo +nightly fmt --all --check` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes locally
- [x] `cargo test --all` passes locally (223 tests, includes new `completion_generates_for_all_shells` and `man_renders`)
- [x] `cargo xtask generate-all --check` passes locally
- [x] Runtime `eksup completion <shell>` output byte-for-byte matches committed `completions/*` for all 5 shells (verified via `diff`)
- [x] Runtime `eksup man` output byte-for-byte matches `man/eksup.1`
- [x] `eksup --help` lists new `completion` and `man` subcommands
- [ ] CI green on this PR (verified after push — this is the first PR to exercise the new `check.yaml`)
- [ ] Next release tarball includes `completions/` and `man/` (verified after next tag push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)