### PR TITLE
chore(release): publish to crates.io via cargo-release

### DIFF
--- a/eksup/Cargo.toml
+++ b/eksup/Cargo.toml
@@ -56,8 +56,10 @@ insta = { version = "1", default-features = false, features = ["yaml"] }
 tempfile = { version = "3", default-features = false, features = ["getrandom"] }
 
 [package.metadata.release]
-# Do not publish to crates.io. eksup is distributed via GitHub releases + Homebrew.
-publish = false
+# Publish to crates.io. Binary distribution (GitHub releases + Homebrew) is
+# handled separately by the release workflow, triggered by the tag that
+# cargo-release pushes after a successful `cargo publish`.
+publish = true
 
 # Regenerate completions and man page BEFORE the version bump commit, so the
 # committed `man/eksup.1` (which embeds the version in its `.TH` header) reflects


### PR DESCRIPTION
## Summary

- Flips `[package.metadata.release].publish` from `false` to `true` in `eksup/Cargo.toml` so `cargo release` runs `cargo publish` as part of the release flow.
- Binary distribution (GitHub releases + Homebrew) continues to be driven by the existing tag-triggered release workflow — no CI changes needed.
- cargo-release's default ordering (`bump → publish → tag → push`) means a failed `cargo publish` aborts the release before any tag is pushed, so binaries + Homebrew can't drift ahead of crates.io.
- Verified locally with `cargo publish -p eksup --dry-run --locked --allow-dirty` (packages and compiles cleanly from the packaged tarball).

Closes #163.

## Notes

- First publish will jump from `0.4.1` (last published 2023-11-28) to the next released version — non-sequential but legal on crates.io.
- No new secrets required: `cargo publish` uses local `~/.cargo/credentials.toml`.
- The README's hardcoded version (`README.md:33`) is already kept in sync via the existing `pre-release-replacements` rule.

## Test plan

- [ ] On next release, confirm `cargo release` publishes successfully to crates.io.
- [ ] After release, confirm `cargo install eksup` fetches the new version.