### PR TITLE
ci: validate the terraform examples on every pull request

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -51,3 +51,27 @@ jobs:
         with:
           workspaces: xtask
       - run: cargo xtask generate-all --check
+
+  # The four example workspaces pin registry modules and providers, and nothing else in
+  # this repository ever resolves them. A dependency refresh that bumps those constraints
+  # was previously only ever checked by whoever happened to run terraform by hand.
+  terraform:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example: [eks-managed, fargate-profile, mixed, self-managed]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_wrapper: false
+      # No backend and no credentials: init resolves modules and providers, validate
+      # checks the configuration against them. `plan` would need AWS credentials and can
+      # read real infrastructure, so it stays out.
+      - run: terraform init -upgrade -input=false -backend=false
+        working-directory: examples/${{ matrix.example }}
+      - run: terraform fmt -check -recursive
+        working-directory: examples/${{ matrix.example }}
+      - run: terraform validate
+        working-directory: examples/${{ matrix.example }}


### PR DESCRIPTION
Adds a `terraform` job to Check, one matrix leg per example directory, running `init -upgrade -backend=false`, `fmt -check` and `validate`.

The four workspaces under `examples/` pin `terraform-aws-modules/eks/aws`, `terraform-aws-modules/vpc/aws`, `hashicorp/aws` and `gavinbunney/kubectl`, and no job in this repository has ever resolved them. That surfaced during the dependency refresh in #186: the module and provider constraints there were stale, and the only thing that caught it was running terraform by hand. Anything that touches those files is otherwise unverified until someone applies it.

`plan` is deliberately absent. It needs AWS credentials and reads real infrastructure. `init` plus `validate` is enough to prove the constraints resolve and the configuration is consistent with the providers they select, which is the whole failure mode a dependency bump introduces.

No lockfile is committed, and this does not start committing one. `.terraform.lock.hcl` is written inside the runner and thrown away with it.
